### PR TITLE
feat: SPCS-direct deployment of ORS with fleet intelligence and demo skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Route Optimisation and Fleet Intelligence on Snowflake
 
+[![Quickstart Guide](https://img.shields.io/badge/Quickstart-Guide-29B5E8?style=for-the-badge&logo=snowflake&logoColor=white)](https://www.snowflake.com/en/developers/guides/oss-install-openrouteservice-native-app/)
+
 An end-to-end geospatial analytics platform deployed entirely on Snowflake. It packages the [OpenRouteService](https://openrouteservice.org/) routing engine on Snowpark Container Services (SPCS), then layers fleet intelligence, route analysis, and retail analytics on top through modular Cortex Code skills.
 
 Everything is deployed and operated through natural-language conversations in [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code) -- each skill is a self-contained playbook the AI agent follows step-by-step.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Route Optimisation and Fleet Intelligence on Snowflake
 
+**Click the button below to get access to the full Snowflake Guide:**
+
 [![Quickstart Guide](https://img.shields.io/badge/Quickstart-Guide-29B5E8?style=for-the-badge&logo=snowflake&logoColor=white)](https://www.snowflake.com/en/developers/guides/oss-install-openrouteservice-native-app/)
 
 An end-to-end geospatial analytics platform deployed entirely on Snowflake. It packages the [OpenRouteService](https://openrouteservice.org/) routing engine on Snowpark Container Services (SPCS), then layers fleet intelligence, route analysis, and retail analytics on top through modular Cortex Code skills.


### PR DESCRIPTION
## Summary

- Migrates from native app to direct SPCS deployment for OpenRouteService
- Adds fleet intelligence, route deviation, dwell analysis, retail catchment, and routing agent skills
- Adds quickstart badge and call-to-action to README

## Test plan

- [ ] Verify ORS services start correctly after deployment
- [ ] Verify fleet intelligence dashboard loads
- [ ] Verify quickstart badge renders on GitHub

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)