### PR TITLE
fix: intro page trips not displaying — wrong schema reference

### DIFF
--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: ors-control-app
-      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.117
+      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.118
       env:
         SNOWFLAKE_DATABASE: "OPENROUTESERVICE_APP"
         SNOWFLAKE_WAREHOUSE: "ROUTING_ANALYTICS"

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/Intro.tsx
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/Intro.tsx
@@ -6,7 +6,7 @@ import { TileLayer, H3HexagonLayer } from '@deck.gl/geo-layers';
 const CARTO_LIGHT = '/api/tiles/{z}/{x}/{y}';
 const SF_VIEW = { longitude: -122.44, latitude: 37.76, zoom: 12, pitch: 0, bearing: 0 };
 const INTRO_DB = 'OPENROUTESERVICE_APP';
-const INTRO_SCHEMA = 'PUBLIC';
+const INTRO_SCHEMA = 'CORE';
 
 const COLORS: [number, number, number][] = [
   [103, 0, 161],


### PR DESCRIPTION
INTRO_SCHEMA was set to 'PUBLIC' but INTRO_TRIPS lives in CORE schema. Bumped control app image to v1.0.118.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)