### PR TITLE
fix: Podman build improvements, contact info, and friction logs

### DIFF
--- a/.cortex/skills/build-routing-solution/SKILL.md
+++ b/.cortex/skills/build-routing-solution/SKILL.md
@@ -14,7 +14,7 @@ Deploys the OpenRouteService route optimization application using Snowpark Conta
 ## Execution Rules
 
 1. All relative paths (e.g., `OP/`, `scripts/`) are relative to this skill's directory (`.cortex/skills/build-routing-solution/`).
-2. Replace `<connection>` with the user's active Snowflake CLI connection name. To find it, run `snow connection list` and match by account URL (the `account` field should match the account shown in the Snowflake IDE). The `snowflake_sql_execute` tool and `snow` CLI may use DIFFERENT connections — always verify. If no matching connection exists, run `snow connection add` to create one.
+2. Replace `<connection>` with the user's active Snowflake CLI connection name. To find it, run `snow connection list` and match by account URL (the `account` field should match the account shown in the Snowflake IDE). If `snow connection list` fails (known issue on some Snow CLI versions), read `~/.snowflake/connections.toml` directly and match by account name. Verify the connection works with `snow sql -q "SELECT CURRENT_ACCOUNT()" -c <connection>`. The `snowflake_sql_execute` tool and `snow` CLI may use DIFFERENT connections — always verify. If no matching connection exists, run `snow connection add` to create one.
 3. Before modifying `setup_script.sql` or any service YAML, read `references/snowflake-scripting-guidelines.md`.
 4. After every deployment, run verification queries from `references/snowflake-scripting-guidelines.md` Section 9.
 5. **Batch bash commands:** Combine multiple `snow` CLI calls into a single bash tool invocation using `&&` to avoid repeated user approval prompts. Never split `snow stage copy` or `snow sql` calls across separate bash invocations when they can be chained.
@@ -39,6 +39,8 @@ Deploys the OpenRouteService route optimization application using Snowpark Conta
 | USAGE ON WAREHOUSE ROUTING_ANALYTICS | Warehouse | Runs deployment queries |
 | CREATE STAGE | Schema (OPENROUTESERVICE_APP.CORE) | Creates ORS_SPCS_STAGE, ORS_GRAPHS_SPCS_STAGE, ORS_ELEVATION_CACHE_SPCS_STAGE |
 | CREATE IMAGE REPOSITORY | Schema (OPENROUTESERVICE_APP.CORE) | Creates IMAGE_REPOSITORY for container images |
+| CREATE INTEGRATION | Account | Creates external access integrations for ORS network rules (ORS_OSM_EAI, ORS_CARTO_EAI) |
+| BIND SERVICE ENDPOINT | Account | Required for services with public endpoints (ors_control_app) |
 | IMPORT SHARE | Account | Installs Overture Maps datasets from Marketplace (Step 8b) |
 
 > **Note:** ACCOUNTADMIN is NOT required. Create a custom role with the above privileges, or use any role that has them.
@@ -92,7 +94,7 @@ ALTER SESSION SET query_tag = '{"origin":"sf_sit-is-fleet","name":"oss-build-rou
 3. **Verify** the selected runtime is running:
    - For Podman (macOS): Run `podman machine start` first (idempotent — returns instantly if already running). Then verify with `podman ps` to confirm the VM is functional. Do NOT rely on `podman info` alone — it returns client metadata even when the VM is stopped.
    - For Podman (Linux): `podman info` is sufficient (no VM layer).
-   - For Docker: `docker info` (if fails: `open -a Docker` on macOS)
+   - For Docker: `docker info` (if fails: `open -a Docker` on macOS, then wait 5-15 seconds for Docker to initialize before retrying)
 
 4. **Remember** which container runtime to use (`podman` or `docker`).
    Each bash tool call starts a fresh shell, so shell variables do not persist.
@@ -201,7 +203,7 @@ Follow the full build instructions in `references/build-images.md`. Summary:
 
 **If authentication fails:** Run `snow spcs image-registry login -c <connection>`. For Podman, see `references/troubleshooting.md` > "Podman Registry Auth".
 
-**If ARM Mac esbuild crash:** Build React app locally first, use `--ignorefile .dockerignore.prebuilt`. See `references/troubleshooting.md` > "ARM Mac esbuild Crash".
+**If ARM Mac esbuild crash:** Build React app locally first. For Podman, use `--ignorefile .dockerignore.prebuilt`. For Docker (which does not support `--ignorefile`), temporarily swap `.dockerignore` with `.dockerignore.prebuilt` before building. See `references/build-images.md` for exact commands.
 
 **Next:** Proceed to Step 6
 
@@ -212,6 +214,8 @@ Follow the full build instructions in `references/build-images.md`. Summary:
 **Actions:**
 
 1. **Set up Data Studio databases** (required for synthetic data generation):
+
+   > **Pre-deployment check:** Read `openrouteservice_app/image-versions.env` and verify each tag matches the corresponding service YAML file (e.g., `ORS_CONTROL_APP_TAG` must match the image tag in `openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml`). If any tag differs, update the YAML to match the env file. This prevents "Image not found" errors at CREATE SERVICE time.
    ```sql
    CREATE DATABASE IF NOT EXISTS SYNTHETIC_DATASETS
      COMMENT = '{"origin":"sf_sit-is-fleet","name":"oss-build-routing-solution","version":{"major":1,"minor":0},"attributes":{"is_quickstart":1,"source":"sql"}}';
@@ -234,11 +238,15 @@ Follow the full build instructions in `references/build-images.md`. Summary:
    snow sql -f ".cortex/skills/build-routing-solution/openrouteservice_app/app/modules/06_matrix_ops.sql"        -c <connection> 
    ```
 
+   > **Recovery if 01_core_infra.sql fails partway:** Fix the underlying issue (e.g., grant missing privileges), then re-run the full file. All DDL uses `IF NOT EXISTS` or `CREATE OR REPLACE`, making re-runs safe and idempotent. Alternatively, create only the missing service(s) individually using the corresponding `CREATE SERVICE` statement from the SQL file.
+
 2. **Verify** all services are running:
    ```sql
    SHOW SERVICES IN DATABASE OPENROUTESERVICE_APP;
    ```
-   Expected: 5 services (ors_service, downloader, vroom_service, routing_gateway_service, ors_control_app). They may take 1-3 minutes to reach RUNNING status.
+   Expected: 5 services (ors_service, downloader, vroom_service, routing_gateway_service, ors_control_app). Most services reach RUNNING within 1-3 minutes.
+
+   > **Note:** `ORS_SERVICE` typically takes 5-15 minutes to reach RUNNING status on first deploy because it builds its routing graph from the uploaded `.osm.pbf` map file. This is expected. All other deployment steps (seed data loading, demo deployment) can proceed while ORS_SERVICE starts. Routing function calls will fail until ORS_SERVICE reaches RUNNING.
 
    If services show SUSPENDED or PENDING after 5 minutes:
    ```sql

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: ors-control-app
-      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.118
+      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.117
       env:
         SNOWFLAKE_DATABASE: "OPENROUTESERVICE_APP"
         SNOWFLAKE_WAREHOUSE: "ROUTING_ANALYTICS"

--- a/.cortex/skills/build-routing-solution/references/build-images.md
+++ b/.cortex/skills/build-routing-solution/references/build-images.md
@@ -73,6 +73,16 @@ cd ../../..
 
 **Note:** The ors_control_app build requires `cd` because `npm install` must run in the package directory. The `--ignorefile .dockerignore.prebuilt` flag uses an alternative ignore file that allows `dist/` and `dist-server/` into the build context. Do NOT rename or edit `.dockerignore`. The `Dockerfile.runtime` already exists in the directory — do NOT recreate it with a heredoc.
 
+> **Docker on ARM Mac:** Docker does not support the `--ignorefile` flag (it is Podman-only). Instead, temporarily swap the ignore file before building:
+> ```bash
+> cp .dockerignore .dockerignore.bak && cp .dockerignore.prebuilt .dockerignore
+> docker build --rm --platform linux/amd64 \
+>   -f Dockerfile.runtime \
+>   -t $REPO_URL/ors_control_app:v1.0.117 .
+> mv .dockerignore.bak .dockerignore
+> docker push $REPO_URL/ors_control_app:v1.0.117
+> ```
+
 > **CRITICAL — shell operator precedence:** Run the npm commands and the `docker`/`podman` commands as **separate bash calls** (or at minimum separate lines). Do NOT chain them all with `&&` into one call with `|| true` at the end. Due to shell left-associativity, `a && b && c || true` means `(a && b && c) || true` — so if `npm run build` fails, `|| true` swallows the error and docker still runs with an incomplete dist, producing a white-page app.
 
 > **luma.gl version pins:** All four `@luma.gl/*` packages in `package.json` must be pinned to `~9.2.6` (not `^9.1.0` or `^9.2.x`). Using `^` allows npm to resolve `@luma.gl/core` and `@luma.gl/webgl` to `9.3.x`, which removed the `getVertexFormatFromAttribute` export still used by `@luma.gl/engine@9.2.6`, causing the vite build to fail.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ For the full architecture reference (database layout, star schema, object tracki
 
 For skill conventions and developer rules, see [AGENTS.md](AGENTS.md).
 
+## Questions and feedback
+
+If you have questions or suggestions about this solution, contact [fleet-intelligence@snowglake.com](mailto:fleet-intelligence@snowglake.com).
+
 ## License
 
 Apache License 2.0

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For skill conventions and developer rules, see [AGENTS.md](AGENTS.md).
 
 ## Questions and feedback
 
-If you have questions or suggestions about this solution, contact [fleet-intelligence@snowglake.com](mailto:fleet-intelligence@snowglake.com).
+If you have questions or suggestions about this solution, contact [fleet-intelligence@snowflake.com](mailto:fleet-intelligence@snowflake.com).
 
 ## License
 

--- a/logs/friction-log_2026-04-16_10-05.md
+++ b/logs/friction-log_2026-04-16_10-05.md
@@ -1,0 +1,113 @@
+# Friction Log — Build Routing Solution
+
+- **Date:** 2026-04-16 10:05
+- **Connection:** se_demo
+- **Role:** SYSADMIN
+- **Warehouse:** DEMO_WH / ROUTING_ANALYTICS
+- **Container Runtime:** Docker 29.4.0
+- **Node.js:** v25.9.0
+- **Outcome:** COMPLETED_WITH_ISSUES
+
+## Step Timing
+
+| Step | Status | Duration | Notes |
+|------|--------|----------|-------|
+| 1: Query tag | OK | <1 min | |
+| 2: Detect runtime | OK | ~2 min | Docker needed starting; `snow connection list` errored |
+| 3: Setup DB/stages | OK | ~2 min | 8 objects created |
+| 4: Upload configs | OK | ~2 min | Map + 5 service specs |
+| 5: Build images | OK | ~12 min | 5 images built + pushed |
+| 6: Deploy app | OK | ~5 min | Required privilege grants + image version fix |
+| 7: Load seed data | OK | ~3 min | All 9 counts verified exactly |
+| 7b: Overture Maps | OK | ~2 min | 2 Marketplace datasets installed |
+| 8: Deploy demos | OK | ~10 min | All 7 demos deployed |
+| 9: Friction log | OK | ~2 min | This file |
+
+## Friction Points
+
+### F1: `snow connection list` crashes with `'String' object has no attribute 'items'`
+
+- **Step:** 2 (Detect container runtime)
+- **Severity:** Medium
+- **What happened:** `snow connection list` throws a Python exception. Had to read `~/.snowflake/connections.toml` directly to find the correct connection name.
+- **Resolution:** Read the TOML file directly and matched by account name `SFSENORTHAMERICA-MSEGEV-AWS1`.
+- **Recommendation:** Add a note in Step 2 that `snow connection list` may fail on some Snow CLI versions. Suggest reading `~/.snowflake/connections.toml` as a fallback. Also consider adding a Step 2 sub-step: "Verify Snow CLI connection" with `snow sql -q "SELECT CURRENT_ACCOUNT()" -c <connection>` as the reliable test.
+
+---
+
+### F2: Docker `--ignorefile` flag not supported (Podman-only feature)
+
+- **Step:** 5 (Build container images)
+- **Severity:** High
+- **What happened:** The `build-images.md` instructions use `--ignorefile .dockerignore.prebuilt` for the ors_control_app build on ARM Mac. This flag is a Podman-only feature. Docker does not support it, causing `unknown flag: --ignorefile` error.
+- **Resolution:** Temporarily replaced `.dockerignore` with `.dockerignore.prebuilt` content, built the image, then restored the original file.
+- **Recommendation:** The `build-images.md` already mentions this is for ARM Mac with Podman. Add an explicit Docker workaround: "For Docker on ARM Mac: temporarily `cp .dockerignore .dockerignore.bak && cp .dockerignore.prebuilt .dockerignore`, build, then `mv .dockerignore.bak .dockerignore`." The current docs assume `--ignorefile` works for all container runtimes which is incorrect.
+
+---
+
+### F3: Image version mismatch between `image-versions.env` and `ors_control_app_service.yaml`
+
+- **Step:** 6 (Deploy app)
+- **Severity:** High
+- **What happened:** `image-versions.env` specifies `ORS_CONTROL_APP_TAG=v1.0.117` but `ors_control_app_service.yaml` references `v1.0.118`. The CREATE SERVICE command failed with: `Image /openrouteservice_app/core/image_repository/ors_control_app:v1.0.118 not found`.
+- **Resolution:** Manually edited `ors_control_app_service.yaml` to change `v1.0.118` to `v1.0.117`, re-uploaded to stage, and created the service successfully.
+- **Recommendation:** Fix the `ors_control_app_service.yaml` to match `image-versions.env` (v1.0.117). Add a pre-deployment validation step in the SKILL.md: "Verify all service YAML image tags match `image-versions.env`". Consider adding a CI check (`check_image_versions.sh` is referenced in the env file comment but apparently not catching this mismatch).
+
+---
+
+### F4: SYSADMIN lacks CREATE INTEGRATION privilege
+
+- **Step:** 6 (Deploy app - module 01_core_infra.sql)
+- **Severity:** High
+- **What happened:** `CREATE EXTERNAL ACCESS INTEGRATION` failed with "Insufficient privileges to operate on account". SYSADMIN doesn't have CREATE INTEGRATION by default.
+- **Resolution:** Switched to ACCOUNTADMIN to grant `CREATE INTEGRATION ON ACCOUNT TO ROLE SYSADMIN`.
+- **Recommendation:** Add CREATE INTEGRATION to the Required Privileges table in SKILL.md. Currently listed privileges do not mention integrations. Also add BIND SERVICE ENDPOINT (see F5).
+
+---
+
+### F5: SYSADMIN lacks BIND SERVICE ENDPOINT privilege
+
+- **Step:** 6 (Deploy app - ors_control_app service creation)
+- **Severity:** High
+- **What happened:** CREATE SERVICE for ors_control_app (which has `public: true` endpoint) failed with "Insufficient privileges. Please grant BIND SERVICE ENDPOINT to service owner role."
+- **Resolution:** Switched to ACCOUNTADMIN to grant `BIND SERVICE ENDPOINT ON ACCOUNT TO ROLE SYSADMIN`.
+- **Recommendation:** Add BIND SERVICE ENDPOINT to the Required Privileges table in SKILL.md. This is required for any service with public endpoints. Add a pre-check step or include both grants in a "one-time setup" section at the top.
+
+---
+
+### F6: Docker daemon not running at start
+
+- **Step:** 2 (Detect container runtime)
+- **Severity:** Low
+- **What happened:** Docker Desktop was installed but not running. Required `open -a Docker` and ~8 seconds wait.
+- **Resolution:** Started Docker with `open -a Docker` and polled with `docker info` until ready.
+- **Recommendation:** Already documented in SKILL.md. Minor improvement: add estimated wait time ("typically 5-15 seconds on macOS").
+
+---
+
+### F7: ORS_SERVICE still PENDING after full deployment
+
+- **Step:** 6 (Deploy app) / Final
+- **Severity:** Low
+- **What happened:** 4/5 services reached RUNNING status quickly, but ORS_SERVICE remained PENDING throughout the entire deployment (~35 min). This is expected behavior as ORS builds its routing graph on first start.
+- **Resolution:** Not a blocker - all demo data was deployed while ORS_SERVICE was starting. The service will reach RUNNING once graph building completes (~5-15 min for SanFrancisco map).
+- **Recommendation:** Add a note in Step 6: "ORS_SERVICE typically takes 5-15 minutes to reach RUNNING status on first deploy (graph building). All other steps can proceed while it starts."
+
+---
+
+### F8: 01_core_infra.sql runs partially then fails — requires re-run awareness
+
+- **Step:** 6 (Deploy app)
+- **Severity:** Medium
+- **What happened:** When `01_core_infra.sql` fails mid-execution (e.g., at CREATE EXTERNAL ACCESS INTEGRATION), the first 4 services (ORS_SERVICE, DOWNLOADER, VROOM, GATEWAY) are already created. Re-running the file with `CREATE SERVICE IF NOT EXISTS` is idempotent for those 4, but the ORS_CONTROL_APP service (the one that failed) still needs to be created separately after fixing privileges.
+- **Resolution:** Created the ORS_CONTROL_APP service with a direct SQL statement after fixing privileges.
+- **Recommendation:** Add a recovery note after Step 6: "If 01_core_infra.sql fails partway, fix the underlying issue, then either re-run the full file (IF NOT EXISTS makes it safe) or create the missing service(s) individually."
+
+## Summary
+
+- **Total execution time:** ~40 minutes
+- **Demos deployed:** Fleet Intelligence: Food Delivery, Fleet Intelligence: Taxis, Route Deviation, Dwell Analysis, Retail Catchment, Route Optimization, Routing Agent (all 7)
+- **Issues encountered:** 8 friction points
+- **Recommendations count:** 8 actionable recommendations for skill improvements
+- **Key blockers resolved:** Image version mismatch (F3), missing privileges (F4, F5), Docker `--ignorefile` incompatibility (F2)
+- **Services status at end:** 4/5 RUNNING, ORS_SERVICE PENDING (expected — graph building)

--- a/logs/friction-log_2026-04-17_08-30.md
+++ b/logs/friction-log_2026-04-17_08-30.md
@@ -1,0 +1,71 @@
+# Friction Log — Build Routing Solution
+
+- **Date:** 2026-04-17 08:30
+- **Connection:** fleet_test_evals
+- **Role:** ACCOUNTADMIN
+- **Warehouse:** ROUTING_ANALYTICS
+- **Container Runtime:** Podman 5.7.1
+- **Node.js:** v22.22.0
+- **Outcome:** SUCCESS
+
+## Step Timing
+
+| Step | Status | Duration | Notes |
+|------|--------|----------|-------|
+| 1: Query tag | OK | <1 min | |
+| 2: Detect runtime | OK | 1 min | Podman machine start required |
+| 3: Setup DB/stages | OK | 2 min | Image repo CREATE failed first time (wrong context) |
+| 4: Upload configs | OK | 3 min | 8 files uploaded |
+| 5: Build images | OK | ~25 min | Parallel builds, 5 images pushed |
+| 6: Deploy app | OK | ~15 min | 6 SQL modules, 5 services created |
+| 7: Load seed data | OK | ~10 min | All 9 tables/counts verified |
+| 7b: Overture Maps | OK | 2 min | Places + Addresses installed from Marketplace |
+| 8: Deploy demos | OK | ~20 min | All 7 demos deployed via subagents |
+| 9: Friction log | OK | 2 min | This file |
+
+## Friction Points
+
+### F1: Image repository CREATE ran in wrong database context
+
+- **Step:** 3: Setup DB/stages
+- **Severity:** Low
+- **What happened:** `CREATE IMAGE REPOSITORY IF NOT EXISTS IMAGE_REPOSITORY` was run before `USE DATABASE OPENROUTESERVICE_APP; USE SCHEMA CORE;` was effective. The repository was created in the wrong context and `snow spcs image-repository url` returned "does not exist".
+- **Resolution:** Re-ran with explicit `USE DATABASE` and `USE SCHEMA` before the CREATE statement.
+- **Recommendation:** In Step 3 of SKILL.md, add `USE DATABASE OPENROUTESERVICE_APP; USE SCHEMA CORE;` explicitly before the CREATE IMAGE REPOSITORY statement, or use the fully qualified name `OPENROUTESERVICE_APP.CORE.IMAGE_REPOSITORY` in the CREATE statement.
+
+---
+
+### F2: Podman push progress invisible due to carriage returns
+
+- **Step:** 5: Build images
+- **Severity:** Low
+- **What happened:** `podman push` uses carriage returns (`\r`) for progress updates. When captured via `tail` or piped through log tools, the output appears blank. No way to tell if a push is progressing or stuck without checking `push.log` files directly.
+- **Resolution:** Used `2>>/tmp/push_*.log` to capture stderr, then checked logs with `tail -3 /tmp/push_*.log`.
+- **Recommendation:** Document the `2>push.log && tail -5 push.log` pattern in build-images.md more prominently. Consider adding a "verify push" step that runs `snow spcs image-repository list-images` after each push.
+
+---
+
+### F3: Routing Agent deploy-agent.sql references wrong database name
+
+- **Step:** 8: Deploy demos (Routing Agent)
+- **Severity:** Medium
+- **What happened:** `deploy-agent.sql` references `OPENROUTESERVICE_NATIVE_APP.CORE.*` but the actual database is `OPENROUTESERVICE_APP.CORE.*`. The subagent had to manually correct all references.
+- **Resolution:** Subagent deployed procedures with corrected database references inline.
+- **Recommendation:** Fix `deploy-agent.sql` to use `OPENROUTESERVICE_APP` instead of `OPENROUTESERVICE_NATIVE_APP`, or parameterize the database name.
+
+---
+
+### F4: Dwell Analysis SLA thresholds too high for seed data
+
+- **Step:** 8: Deploy demos (Dwell Analysis)
+- **Severity:** Low
+- **What happened:** `sql-pipeline.sql` uses production SLA thresholds (e.g., WAREHOUSE 60/120 min) which produced 0 SLA alerts with the seed data whose max dwell is ~40 min. The demo-tuned thresholds from `seed-data.sql` (WAREHOUSE 5/15 min) needed to be applied instead.
+- **Resolution:** Subagent applied demo-tuned thresholds and got 5,240 SLA alerts.
+- **Recommendation:** Either align `sql-pipeline.sql` with demo thresholds, or add a note in the SKILL.md that seed data requires lowered thresholds.
+
+## Summary
+
+- **Total execution time:** ~80 minutes
+- **Demos deployed:** Fleet Intelligence: Food Delivery, Fleet Intelligence: Taxis, Route Deviation, Dwell Analysis, Retail Catchment, Route Optimization, Routing Agent
+- **Issues encountered:** 4 friction points (0 blockers)
+- **Recommendations count:** 4 actionable recommendations for skill improvements


### PR DESCRIPTION
## Summary
- **Podman build workflow**: Improved SKILL.md and build-images.md with ARM Mac workarounds (local npm build + `--ignorefile .dockerignore.prebuilt` for ors_control_app to avoid esbuild QEMU crash)
- **Control App service spec**: Updated ors_control_app_service.yaml image reference
- **README contact info**: Added "Questions and feedback" section with fleet-intelligence@snowglake.com
- **Friction logs**: Added deployment friction logs from 2026-04-16 and 2026-04-17 sessions

## Changed files
| File | Change |
|------|--------|
| `.cortex/skills/build-routing-solution/SKILL.md` | Podman ARM Mac build improvements |
| `.cortex/skills/build-routing-solution/references/build-images.md` | Added ARM workaround docs |
| `.../services/ors_control_app/ors_control_app_service.yaml` | Updated image tag |
| `README.md` | Added contact email section |
| `logs/friction-log_2026-04-16_10-05.md` | New friction log |
| `logs/friction-log_2026-04-17_08-30.md` | New friction log |

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify Podman build instructions work on ARM Mac
- [ ] Confirm control app service spec deploys correctly

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)