### PR TITLE
feat: v1.0.138 - restore Intro demo page

### DIFF
--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
@@ -1,11 +1,11 @@
 spec:
   containers:
     - name: ors-control-app
-      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.137
+      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.138
       env:
         SNOWFLAKE_DATABASE: "OPENROUTESERVICE_APP"
         SNOWFLAKE_WAREHOUSE: "ROUTING_ANALYTICS"
-        APP_VERSION: "1.0.132"
+        APP_VERSION: "1.0.138"
       resources:
         requests:
           cpu: "0.5"

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/App.tsx
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Info, Activity, MapPin, Wrench, Grid3X3, Database, Route, Clock, Truck, CarTaxiFront, GitBranch, Store, Bot, Stethoscope, ChevronDown, ChevronRight } from 'lucide-react';
+import { Info, Map, Activity, MapPin, Wrench, Grid3X3, Database, Route, Clock, Truck, CarTaxiFront, GitBranch, Store, Bot, Stethoscope, ChevronDown, ChevronRight } from 'lucide-react';
 import ServiceManager from './components/ServiceManager';
 import RegionBuilder from './components/RegionBuilder';
 import MatrixBuilder from './components/MatrixBuilder';
@@ -17,6 +17,7 @@ import AgentPlayground from './components/AgentPlayground';
 import FleetDataStudio from './components/FleetDataStudio';
 import Diagnostics from './components/Diagnostics';
 import About from './components/About';
+import Intro from './components/Intro';
 import Home from './components/Home';
 import RegionSwitcher from './shared/RegionSwitcher';
 import VehicleTypeSwitcher from './shared/VehicleTypeSwitcher';
@@ -32,6 +33,7 @@ interface NavGroup {
 
 const GETTING_STARTED: NavGroup[] = [
   { key: 'about', label: 'About', icon: Info },
+  { key: 'intro', label: 'Intro', icon: Map },
   { key: 'services', label: 'Status & Health', icon: Activity },
 ];
 
@@ -123,7 +125,7 @@ export default function App() {
   const activeCategory = activeTab.includes(':') ? activeTab.split(':')[0] : activeTab;
   const activeSubTab = activeTab.includes(':') ? activeTab.split(':')[1] : undefined;
 
-  const FULL_WIDTH_TABS = ['dwell', 'fleet-delivery', 'route-deviation', 'retail', 'agent'];
+  const FULL_WIDTH_TABS = ['intro', 'dwell', 'fleet-delivery', 'route-deviation', 'retail', 'agent'];
   const isFullWidth = FULL_WIDTH_TABS.includes(activeCategory);
 
   const renderNavGroup = (g: NavGroup) => {
@@ -214,6 +216,7 @@ export default function App() {
           <main className={`app-main${isFullWidth ? ' full-width' : ''}`}>
             {activeTab === 'home' && <Home onNavigate={navigateTo} />}
             {activeTab === 'about' && <About />}
+            {activeTab === 'intro' && <Intro />}
             {activeTab === 'services' && <ServiceManager />}
             {activeTab === 'regions' && <RegionBuilder />}
             {activeTab === 'functions' && <FunctionTester />}


### PR DESCRIPTION
## Summary
- Re-wired the orphaned `Intro.tsx` component (H3 grid + trips DeckGL map over SF) back into the sidebar under **Getting Started > Intro**
- The page was accidentally dropped during the sidebar reorganization in `580d29e` but the component file remained in the repo
- Added `intro` to `FULL_WIDTH_TABS` for proper full-bleed map rendering
- Bumped image to v1.0.138, deployed and verified on SPCS

## Test plan
- [ ] Open the control app and verify "Intro" appears under Getting Started (after About)
- [ ] Click Intro and confirm the DeckGL map renders with H3 hexagons and trip paths
- [ ] Verify other pages still load correctly (About, Status & Health, etc.)

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)