### PR TITLE
fix(routing-agent): add tracking tag to ROUTING_AGENT COMMENT

### DIFF
--- a/.cortex/skills/routing-agent/references/agent-definitions.md
+++ b/.cortex/skills/routing-agent/references/agent-definitions.md
@@ -341,7 +341,7 @@ Creates the Cortex Agent with tool bindings to the three stored procedures.
 
 ```sql
 CREATE OR REPLACE AGENT FLEET_INTELLIGENCE.ROUTING_AGENT.ROUTING_AGENT
-COMMENT = 'Routing agent using OpenRouteService for directions, isochrones, and optimization within the loaded map region.'
+COMMENT = '{"origin":"sf_sit-is-fleet","name":"oss-deploy-snowflake-intelligence-routing-agent","version":{"major":1,"minor":0},"attributes":{"is_quickstart":1,"source":"sql"}}'
 PROFILE = '{"display_name": "Routing Agent", "color": "green"}'
 FROM SPECIFICATION $$
 models:

--- a/.cortex/skills/routing-agent/references/deploy-agent.sql
+++ b/.cortex/skills/routing-agent/references/deploy-agent.sql
@@ -344,7 +344,7 @@ ALTER PROCEDURE FLEET_INTELLIGENCE.ROUTING_AGENT.TOOL_ROUTE_OPTIMIZATION(VARCHAR
 
 -- CREATE AGENT with tool bindings
 CREATE OR REPLACE AGENT FLEET_INTELLIGENCE.ROUTING_AGENT.ROUTING_AGENT
-COMMENT = 'Routing agent using OpenRouteService for directions, isochrones, and optimization within the loaded map region.'
+COMMENT = '{"origin":"sf_sit-is-fleet","name":"oss-deploy-snowflake-intelligence-routing-agent","version":{"major":1,"minor":0},"attributes":{"is_quickstart":1,"source":"sql"}}'
 PROFILE = '{"display_name": "Routing Agent", "color": "green"}'
 FROM SPECIFICATION $$
 models:


### PR DESCRIPTION
## Summary
- Replaced the descriptive text COMMENT on `CREATE AGENT ROUTING_AGENT` with the required `sf_sit-is-fleet` tracking tag JSON
- Fixed in both `deploy-agent.sql` and `agent-definitions.md`
- Already applied live via `ALTER AGENT SET COMMENT`

## Test plan
- [ ] Verify `SHOW AGENTS IN SCHEMA FLEET_INTELLIGENCE.ROUTING_AGENT` shows the tracking tag JSON in the comment column
- [ ] Run `routing-solution-cleanup` discovery queries and confirm the agent is now discoverable via COMMENT tag

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)