### PR TITLE
fix(matrix): add missing MATRIX_TABULAR_W wrapper for non-default regions

### DIFF
--- a/.cortex/skills/build-routing-solution/openrouteservice_app/app/modules/02_routing_functions.sql
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/app/modules/02_routing_functions.sql
@@ -156,6 +156,14 @@
       AS
       'SELECT OPENROUTESERVICE_APP.CORE._MATRIX_TABULAR_RAW(method, origin, destinations, region)';
 
+   -- MATRIX_TABULAR_W (region-first arg order wrapper for BUILD_TRAVEL_TIME_RANGE_REGION non-default path) - returns VARIANT
+   CREATE OR REPLACE FUNCTION OPENROUTESERVICE_APP.CORE.MATRIX_TABULAR_W(region VARCHAR, method VARCHAR, origin ARRAY, destinations ARRAY)
+      RETURNS VARIANT
+      LANGUAGE SQL
+      COMMENT = '{"origin":"sf_sit-is-fleet","name":"build-routing-solution","version":"2.0","attributes":{"component":"routing"}}'
+      AS
+      'SELECT OPENROUTESERVICE_APP.CORE.MATRIX_TABULAR(method, origin, destinations, region)';
+
    -- ORS_STATUS - returns VARIANT
    CREATE OR REPLACE FUNCTION OPENROUTESERVICE_APP.CORE.ORS_STATUS(region VARCHAR DEFAULT NULL)
       RETURNS VARIANT


### PR DESCRIPTION
## Summary
- Adds the missing `MATRIX_TABULAR_W(region, method, origin, destinations)` wrapper to [02_routing_functions.sql](.cortex/skills/build-routing-solution/openrouteservice_app/app/modules/02_routing_functions.sql).
- Unblocks matrix builds for all non-default regions. Without this wrapper, every batch INSERT in `BUILD_TRAVEL_TIME_RANGE_REGION` fails with `error 2141: Unknown user-defined function OPENROUTESERVICE_APP.CORE.MATRIX_TABULAR_W`, leaving the build stuck in `STAGE='BUILDING'` with 0 rows while workers exhaust exponential-backoff retries (10/20/40/80/160s).

## Background
`server/index.ts:1242` routes non-default-region builds through `MATRIX_TABULAR_W` because `BUILD_TRAVEL_TIME_RANGE_REGION` builds the call with region-first arg order, while `MATRIX_TABULAR(method, origin, destinations, region)` expects region last. The wrapper-name reference was added by a prior cherry-pick but the wrapper SQL itself never made it into the routing-functions module.

## Fix
The wrapper just re-orders args and delegates to the existing `MATRIX_TABULAR`:
```sql
CREATE OR REPLACE FUNCTION OPENROUTESERVICE_APP.CORE.MATRIX_TABULAR_W(region VARCHAR, method VARCHAR, origin ARRAY, destinations ARRAY)
   RETURNS VARIANT LANGUAGE SQL
   AS 'SELECT OPENROUTESERVICE_APP.CORE.MATRIX_TABULAR(method, origin, destinations, region)';
```

## Test plan
- [x] Hot-fixed live account `wgb26798` with the same SQL
- [x] Re-ran Hamburg `driving-hgv` RES7 build: completed in 77s, 1066 hexagons -> 1,135,290 travel-time pairs (no errors)
- [ ] Verify on a fresh deployment that `02_routing_functions.sql` now creates 4 matrix-related functions: `MATRIX` x2, `MATRIX_TABULAR`, `MATRIX_TABULAR_W`
- [ ] Run a non-default-region matrix build end-to-end through the Matrix Builder UI

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)