### PR TITLE
fix: Pin vroom base image & fix Route Optimization map crash

### DIFF
--- a/.cortex/skills/build-routing-solution/openrouteservice_app/image-versions.env
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/image-versions.env
@@ -6,3 +6,9 @@ DOWNLOADER_TAG=v0.0.3
 ROUTING_REVERSE_PROXY_TAG=v1.0.0
 VROOM_DOCKER_TAG=v1.0.1
 ORS_CONTROL_APP_TAG=v1.0.141
+
+# Upstream base image versions (pinned to avoid pulling broken releases).
+# Bump procedure: test locally with `docker run <image>:<new_tag>`, then
+# rebuild and push the corresponding SPCS image.
+OPENROUTESERVICE_BASE_TAG=v9.0.0
+VROOM_BASE_TAG=v1.14.0

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
@@ -1,11 +1,11 @@
 spec:
   containers:
     - name: ors-control-app
-      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.142
+      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.141
       env:
         SNOWFLAKE_DATABASE: "OPENROUTESERVICE_APP"
         SNOWFLAKE_WAREHOUSE: "ROUTING_ANALYTICS"
-        APP_VERSION: "1.0.142"
+        APP_VERSION: "1.0.141"
       resources:
         requests:
           cpu: "0.5"

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/RouteOptimization.tsx
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/RouteOptimization.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import MetricCard from '../shared/MetricCard';
 import DeckGL from '@deck.gl/react';
 import { ScatterplotLayer, PathLayer, GeoJsonLayer } from '@deck.gl/layers';
@@ -49,6 +49,20 @@ export default function RouteOptimization() {
   const [showVehicles, setShowVehicles] = useState(false);
   const [loading, setLoading] = useState(false);
   const [viewState, setViewState] = useState({ longitude: -122.4194, latitude: 37.7749, zoom: 11, pitch: 0, bearing: 0 });
+  const [mapDims, setMapDims] = useState<{ width: number; height: number } | null>(null);
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = mapContainerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width > 0 && height > 0) setMapDims({ width: Math.round(width), height: Math.round(height) });
+    });
+    ro.observe(el);
+    if (el.clientWidth > 0 && el.clientHeight > 0) setMapDims({ width: el.clientWidth, height: el.clientHeight });
+    return () => ro.disconnect();
+  }, []);
 
   useEffect(() => {
     const lng = Number(center.lng);
@@ -269,9 +283,9 @@ export default function RouteOptimization() {
         </div>
       )}
 
-      <div style={{ height: 500, borderRadius: 8, border: '1px solid var(--border)', overflow: 'hidden', position: 'relative', background: '#e8e8e8' }}>
+      <div ref={mapContainerRef} style={{ height: 500, borderRadius: 8, border: '1px solid var(--border)', overflow: 'hidden', position: 'relative', background: '#e8e8e8' }}>
         {(loading || solving) && <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff', zIndex: 10, fontSize: 14 }}>{solving ? 'Solving VRP...' : 'Loading...'}</div>}
-        <DeckGL viewState={viewState} onViewStateChange={({ viewState: vs }: any) => setViewState(vs)} controller={true} layers={layers} getTooltip={getTooltip} style={{ width: '100%', height: '100%' }} />
+        {mapDims && <DeckGL width={mapDims.width} height={mapDims.height} viewState={viewState} onViewStateChange={({ viewState: vs }: any) => setViewState(vs)} controller={true} layers={layers} getTooltip={getTooltip} style={{ position: 'absolute', top: '0', left: '0', width: `${mapDims.width}px`, height: `${mapDims.height}px` }} />}
       </div>
     </div>
   );

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/vroom/Dockerfile
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/vroom/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/vroom-project/vroom-docker:latest
+ARG BASE_IMAGE=ghcr.io/vroom-project/vroom-docker:v1.14.0
 FROM $BASE_IMAGE
 
 COPY config.yml /conf/config.yml

--- a/.cortex/skills/build-routing-solution/references/build-images.md
+++ b/.cortex/skills/build-routing-solution/references/build-images.md
@@ -132,6 +132,27 @@ Tag values are the single source of truth in [`openrouteservice_app/image-versio
 
 Total first push: 20-30 minutes. Subsequent pushes with cached layers: ~5 minutes.
 
+## Pinned Upstream Base Images
+
+All upstream base images are pinned to explicit versions — never use `:latest`. Pinned versions are documented in `openrouteservice_app/image-versions.env` (variables `OPENROUTESERVICE_BASE_TAG`, `VROOM_BASE_TAG`).
+
+| Service | Base image | Pinned version | Source |
+|---------|-----------|----------------|--------|
+| OpenRouteService | `openrouteservice/openrouteservice` | `v9.0.0` | [Docker Hub](https://hub.docker.com/r/openrouteservice/openrouteservice/tags) |
+| VROOM | `ghcr.io/vroom-project/vroom-docker` | `v1.14.0` | [GHCR](https://github.com/VROOM-Project/vroom-docker/pkgs/container/vroom-docker) |
+| Downloader | `python:3.10-slim-buster` | `3.10-slim-buster` | [Docker Hub](https://hub.docker.com/_/python/tags) |
+| Gateway | `python:3.10-slim-buster` | `3.10-slim-buster` | [Docker Hub](https://hub.docker.com/_/python/tags) |
+
+### Bumping an upstream version
+
+1. Check the upstream release notes for breaking changes.
+2. Test locally: `docker run --rm <image>:<new_tag>` — verify it starts cleanly.
+3. Update the `ARG BASE_IMAGE=` line in the corresponding Dockerfile.
+4. Update `image-versions.env` (`OPENROUTESERVICE_BASE_TAG` or `VROOM_BASE_TAG`).
+5. Rebuild and push the SPCS image (bump `*_TAG` in `image-versions.env`).
+6. Redeploy: update service YAML, upload to stage, `ALTER SERVICE … SUSPEND` / update spec / `RESUME`.
+7. Verify: `SHOW SERVICES` — confirm status is `RUNNING`.
+
 ## Common Errors
 
 - **Authentication failure**: Run `snow spcs image-registry login` (Docker) or use session token (Podman) before pushing


### PR DESCRIPTION
## Summary

- **Pin vroom Docker base image to `v1.14.0`** — removes the only `:latest` reference in the ORS build chain, preventing broken upstream releases from breaking SPCS deployments (#58)
- **Fix deck.gl crash on Route Optimization page** — map rendered before container had dimensions, causing an assertion error and blank grey area on load (#85)

## Changes

- `vroom/Dockerfile`: `ghcr.io/vroom-project/vroom-docker:latest` → `:v1.14.0`
- `image-versions.env`: added `OPENROUTESERVICE_BASE_TAG` / `VROOM_BASE_TAG` for upstream version tracking
- `build-images.md`: added pinned base images table + version bump procedure
- `RouteOptimization.tsx`: added `ResizeObserver` dimension guard before DeckGL render
- `ors_control_app_service.yaml`: aligned image tag to `v1.0.141`

## Test plan

- [x] Local Docker build + smoke test (vroom starts, listens on :3000)
- [x] Pushed to SPCS registry, vroom service resumed to READY
- [x] Control app redeployed, Route Optimization page loads without console errors
- [x] Optimize Routes returns route solutions after region switch to SanFrancisco