### PR TITLE
feat(build-routing-solution): cost guard followups - PBF download pat…

### DIFF
--- a/.cortex/skills/build-routing-solution/openrouteservice_app/app/modules/03_region_management.sql
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/app/modules/03_region_management.sql
@@ -160,6 +160,33 @@ BEGIN
             ALTER SERVICE IF EXISTS OPENROUTESERVICE_APP.CORE.downloader SET AUTO_SUSPEND_SECS = 14400;
         EXCEPTION WHEN OTHER THEN NULL;
         END;
+        -- Cost guard parity (download path): if a per-region service exists
+        -- AND is not in READY status, suspend it. Service almost certainly
+        -- doesn't exist yet (download runs before CREATE SERVICE) so this is
+        -- a no-op in normal flow, but the audit row tells us the path fired.
+        LET dl_svc_state VARCHAR DEFAULT '';
+        BEGIN
+            EXECUTE IMMEDIATE 'SHOW SERVICES LIKE ''ORS_SERVICE_'
+                || UPPER(:P_REGION) || ''' IN SCHEMA OPENROUTESERVICE_APP.CORE';
+            LET dl_rs RESULTSET := (SELECT "status" AS S
+                                    FROM TABLE(RESULT_SCAN(LAST_QUERY_ID())) LIMIT 1);
+            LET dl_csc CURSOR FOR dl_rs;
+            FOR r IN dl_csc DO dl_svc_state := COALESCE(r.S, ''); END FOR;
+        EXCEPTION WHEN OTHER THEN dl_svc_state := '';
+        END;
+        IF (:dl_svc_state IN ('FAILED', 'PENDING', 'SUSPENDED', '')) THEN
+            BEGIN
+                EXECUTE IMMEDIATE 'ALTER SERVICE IF EXISTS OPENROUTESERVICE_APP.CORE.ORS_SERVICE_'
+                    || UPPER(:P_REGION) || ' SUSPEND';
+            EXCEPTION WHEN OTHER THEN NULL;
+            END;
+            BEGIN
+                INSERT INTO OPENROUTESERVICE_APP.CORE.COST_GUARD_LOG (REGION, ACTION, FIRED_AT, REASON)
+                VALUES (:P_REGION, 'pbf_download_failure_suspend', CURRENT_TIMESTAMP(),
+                        'svc_state=' || :dl_svc_state || '; err=' || :dl_err);
+            EXCEPTION WHEN OTHER THEN NULL;
+            END;
+        END IF;
         UPDATE OPENROUTESERVICE_APP.CORE.REGION_PROVISION_JOBS SET STATUS='FAILED', MESSAGE=:dl_err WHERE JOB_ID = :P_JOB_ID;
         RETURN OBJECT_CONSTRUCT('status', 'FAILED', 'error', :dl_err)::VARCHAR;
     END;
@@ -679,12 +706,80 @@ AS
 $$
 BEGIN
     LET svc_name VARCHAR := 'ORS_SERVICE_' || UPPER(:P_REGION);
-
     EXECUTE IMMEDIATE 'DROP SERVICE IF EXISTS OPENROUTESERVICE_APP.CORE.' || svc_name;
-
     DELETE FROM OPENROUTESERVICE_APP.CORE.REGION_ORS_MAP WHERE REGION = :P_REGION;
-
     RETURN 'Dropped region ORS for ' || :P_REGION;
+END;
+$$;
+
+-- =============================================================================
+-- SOFT_SUSPEND_REGION
+-- Park a region's compute cheaply without dropping the service object. Refuses
+-- if a provision job is in-flight to honor M1 (AUTO_SUSPEND_SECS=0 during
+-- BUILDING_GRAPH) and M5/M10 (alive containers must be left to finish).
+-- Resume is fast (~1-2 min) via M11/M12 graph reuse.
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE OPENROUTESERVICE_APP.CORE.SOFT_SUSPEND_REGION(P_REGION VARCHAR)
+RETURNS STRING
+LANGUAGE SQL
+COMMENT = '{"origin":"sf_sit-is-fleet","name":"build-routing-solution","version":"1.0","attributes":{"component":"cost-guard"}}'
+EXECUTE AS OWNER
+AS
+$$
+DECLARE
+    rs RESULTSET;
+    in_flight_count INTEGER DEFAULT 0;
+BEGIN
+    LET svc_name VARCHAR := 'ORS_SERVICE_' || UPPER(:P_REGION);
+    LET pool_name VARCHAR := 'ORS_POOL_' || UPPER(:P_REGION);
+
+    rs := (SELECT COUNT(*) AS C
+           FROM OPENROUTESERVICE_APP.CORE.REGION_PROVISION_JOBS
+           WHERE REGION = :P_REGION
+             AND DISMISSED = FALSE
+             AND STATUS = 'RUNNING'
+             AND STAGE IN ('DOWNLOADING','CONFIGURING','STARTING_SERVICE',
+                           'WAITING_FOR_SERVICE','BUILDING_GRAPH'));
+    LET c CURSOR FOR rs;
+    FOR r IN c DO in_flight_count := r.C; END FOR;
+
+    IF (:in_flight_count > 0) THEN
+        BEGIN
+            INSERT INTO OPENROUTESERVICE_APP.CORE.COST_GUARD_LOG (REGION, ACTION, FIRED_AT, REASON)
+            VALUES (:P_REGION, 'soft_suspend_refused', CURRENT_TIMESTAMP(),
+                    'in-flight provision job - refusing suspend to preserve build');
+        EXCEPTION WHEN OTHER THEN NULL;
+        END;
+        RETURN 'REFUSED: in-flight provision job for ' || :P_REGION ||
+               '. Use DIAGNOSE_REGION first; dismiss the job before suspending.';
+    END IF;
+
+    LET ors_ready VARCHAR DEFAULT 'unknown';
+    BEGIN
+        rs := (EXECUTE IMMEDIATE 'SELECT TRY_PARSE_JSON(OPENROUTESERVICE_APP.CORE.ORS_STATUS('''
+            || :P_REGION || ''')::VARCHAR):service_ready::VARCHAR AS R');
+        LET c2 CURSOR FOR rs;
+        FOR r IN c2 DO ors_ready := COALESCE(r.R, 'unknown'); END FOR;
+    EXCEPTION WHEN OTHER THEN ors_ready := 'unknown';
+    END;
+
+    BEGIN
+        EXECUTE IMMEDIATE 'ALTER SERVICE IF EXISTS OPENROUTESERVICE_APP.CORE.' || svc_name || ' SUSPEND';
+    EXCEPTION WHEN OTHER THEN NULL;
+    END;
+    BEGIN
+        EXECUTE IMMEDIATE 'ALTER COMPUTE POOL IF EXISTS ' || pool_name || ' SUSPEND';
+    EXCEPTION WHEN OTHER THEN NULL;
+    END;
+    BEGIN
+        INSERT INTO OPENROUTESERVICE_APP.CORE.COST_GUARD_LOG (REGION, ACTION, FIRED_AT, REASON)
+        VALUES (:P_REGION, 'soft_suspend_region', CURRENT_TIMESTAMP(),
+                'service+pool suspended (no in-flight job; service_ready=' || :ors_ready ||
+                '); resume preserves service object');
+    EXCEPTION WHEN OTHER THEN NULL;
+    END;
+    RETURN 'Soft-suspended ' || :P_REGION ||
+           ' (resume via resume_region_ors). service_ready was ' || :ors_ready;
 END;
 $$;
 


### PR DESCRIPTION
…h and SOFT_SUSPEND_REGION

Two additive changes building on feat/cost-guard-v3-head-aligned:

1. PBF download EXCEPTION cost guard (item 4): the inner download exception is caught and returns STATUS=FAILED via early return without reaching the outer EXCEPTION block. Add the same SHOW SERVICES probe + IN-list + suspend + COST_GUARD_LOG insert pattern to that path. Service almost certainly does not exist yet at that point, so the SUSPEND is a no-op in normal flow, but the audit row gives visibility and future-proofs against any code reordering.

2. SOFT_SUSPEND_REGION proc (item 2): preserves the service object (no STOP ALL on the pool) so resume is fast (~1-2 min) via M11/M12 graph reuse. Refuses if a provision job is in-flight (STATUS=RUNNING and STAGE in DOWNLOADING/CONFIGURING/STARTING_SERVICE/WAITING_FOR_SERVICE/ BUILDING_GRAPH) to honor M1 (AUTO_SUSPEND_SECS=0 during BUILDING_GRAPH) and M5/M10 (alive containers must be left to finish). Snapshots service_ready into the audit row so we can later distinguish suspended- ready-region from suspended-warming-up-region.

Smoke-tested live: refusal path fires correctly with synthetic in-flight job; success path fires when no in-flight job exists; both audit rows appear in COST_GUARD_LOG.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)