### PR TITLE
fix(ors_control_app): use design tokens for overflow menu (light-them…

### DIFF
--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/index.html
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/index.html
@@ -119,12 +119,13 @@
       /* Overflow menu (...) */
       .overflow-menu { position: relative; display: inline-block; }
       .overflow-menu-trigger { padding: 2px 10px; font-size: 16px; line-height: 1; min-width: 28px; }
-      .overflow-menu-panel { position: absolute; right: 0; top: calc(100% + 4px); z-index: 20; background: var(--panel, #1f2937); border: 1px solid var(--border); border-radius: 6px; box-shadow: 0 4px 16px rgba(0,0,0,0.25); min-width: 180px; padding: 4px; display: flex; flex-direction: column; gap: 2px; }
-      .overflow-menu-item { display: block; width: 100%; text-align: left; padding: 6px 10px; font-size: 12px; background: none; border: 0; color: var(--text-primary, inherit); border-radius: 4px; cursor: pointer; }
-      .overflow-menu-item:hover:not(:disabled) { background: rgba(255,255,255,0.06); }
-      .overflow-menu-item.danger { color: #e53935; }
-      .overflow-menu-item.danger.confirm { background: rgba(229,57,53,0.18); color: #fff; font-weight: 600; }
-      .overflow-menu-item.disabled, .overflow-menu-item:disabled { opacity: 0.5; cursor: not-allowed; }
+      .overflow-menu-panel { position: absolute; right: 0; top: calc(100% + 4px); z-index: 20; background: var(--bg); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 4px 16px rgba(0,0,0,0.12); min-width: 180px; padding: 4px; display: flex; flex-direction: column; gap: 2px; }
+      .overflow-menu-item { display: block; width: 100%; text-align: left; padding: 6px 10px; font-size: 12px; background: none; border: 0; color: var(--text); border-radius: 4px; cursor: pointer; }
+      .overflow-menu-item:hover:not(:disabled) { background: rgba(0,0,0,0.04); }
+      .overflow-menu-item.danger { color: var(--red); }
+      .overflow-menu-item.danger:hover:not(:disabled) { background: rgba(229,72,77,0.08); }
+      .overflow-menu-item.danger.confirm { background: rgba(229,72,77,0.12); color: var(--red); font-weight: 600; }
+      .overflow-menu-item.disabled, .overflow-menu-item:disabled { color: var(--text-secondary); opacity: 0.7; cursor: not-allowed; }
 
       @media (max-width: 720px) {
         .pool-section-header { flex-direction: column; align-items: flex-start; }


### PR DESCRIPTION
…e polish)

Replaces hardcoded dark colors in .overflow-menu-panel/.overflow-menu-item with the existing design tokens (--bg, --text, --red, --text-secondary) so the menu reads correctly on the light theme. Adds a danger-hover background for the Drop action.