### PR TITLE
fix(ors-control-app): atomic preset activation + function-tester polygon clipping

### DIFF
--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: ors-control-app
-      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.213
+      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.214
       env:
         SNOWFLAKE_DATABASE: "OPENROUTESERVICE_APP"
         SNOWFLAKE_WAREHOUSE: "ROUTING_ANALYTICS"

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: ors-control-app
-      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.212
+      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.0.213
       env:
         SNOWFLAKE_DATABASE: "OPENROUTESERVICE_APP"
         SNOWFLAKE_WAREHOUSE: "ROUTING_ANALYTICS"

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/server/index.ts
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/server/index.ts
@@ -967,20 +967,22 @@ app.get('/api/regions/provisioned', async (_req, res) => {
       } catch { serviceStatus = 'NOT_FOUND'; }
 
       let bbox = c.bbox;
+      let boundaryGeoJson: string | null = null;
       const bboxInvalid = !bbox
         || bbox.min_lat == null || bbox.max_lat == null || bbox.min_lon == null || bbox.max_lon == null
         || (bbox.min_lat === 0 && bbox.max_lat === 0 && bbox.min_lon === 0 && bbox.max_lon === 0);
-      if (bboxInvalid) {
-        try {
-          const safeRegion = sanitizeIdentifier(c.region);
-          const catRows = await runSql(`SELECT MIN_LAT, MAX_LAT, MIN_LON, MAX_LON FROM ${SF_DATABASE}.CORE.REGION_CATALOG WHERE UPPER(REGION_KEY) = UPPER('${safeRegion}') OR UPPER(REGION_NAME) = UPPER('${safeRegion}') LIMIT 1`);
-          const cat = catRows?.[0];
-          if (cat && cat.MIN_LAT != null && cat.MAX_LAT != null && cat.MIN_LON != null && cat.MAX_LON != null
+      try {
+        const safeRegion = sanitizeIdentifier(c.region);
+        const catRows = await runSql(`SELECT MIN_LAT, MAX_LAT, MIN_LON, MAX_LON, CAST(ST_ASGEOJSON(BOUNDARY) AS VARCHAR) AS BOUNDARY_GEOJSON FROM ${SF_DATABASE}.CORE.REGION_CATALOG WHERE UPPER(REGION_KEY) = UPPER('${safeRegion}') OR UPPER(REGION_NAME) = UPPER('${safeRegion}') LIMIT 1`);
+        const cat = catRows?.[0];
+        if (cat) {
+          if (bboxInvalid && cat.MIN_LAT != null && cat.MAX_LAT != null && cat.MIN_LON != null && cat.MAX_LON != null
               && !(cat.MIN_LAT === 0 && cat.MAX_LAT === 0 && cat.MIN_LON === 0 && cat.MAX_LON === 0)) {
             bbox = { min_lat: cat.MIN_LAT, max_lat: cat.MAX_LAT, min_lon: cat.MIN_LON, max_lon: cat.MAX_LON };
           }
-        } catch {}
-      }
+          if (cat.BOUNDARY_GEOJSON) boundaryGeoJson = cat.BOUNDARY_GEOJSON;
+        }
+      } catch {}
 
       let graphReadiness: any = null;
       if (serviceStatus === 'RUNNING' || serviceStatus === 'READY') {
@@ -1009,7 +1011,7 @@ app.get('/api/regions/provisioned', async (_req, res) => {
         }
       }
 
-      return { ...c, bbox, serviceStatus, functionExists: true, graphReadiness };
+      return { ...c, bbox, boundaryGeoJson, serviceStatus, functionExists: true, graphReadiness };
     }));
 
     let defaultStatus = 'NOT_FOUND';
@@ -1043,6 +1045,11 @@ app.get('/api/regions/provisioned', async (_req, res) => {
       }
     }
     if (defaultStatus !== 'NOT_FOUND') {
+      let defaultBoundaryGeoJson: string | null = null;
+      try {
+        const catRows = await runSql(`SELECT CAST(ST_ASGEOJSON(BOUNDARY) AS VARCHAR) AS BOUNDARY_GEOJSON FROM ${SF_DATABASE}.CORE.REGION_CATALOG WHERE UPPER(REGION_KEY) = 'SAN_FRANCISCO' OR UPPER(REGION_KEY) = 'DEFAULT' OR UPPER(REGION_NAME) = 'SAN FRANCISCO' LIMIT 1`);
+        defaultBoundaryGeoJson = catRows?.[0]?.BOUNDARY_GEOJSON ?? null;
+      } catch {}
       enriched.unshift({
         region: 'default',
         display_name: 'San Francisco (Default)',
@@ -1051,6 +1058,7 @@ app.get('/api/regions/provisioned', async (_req, res) => {
         functionExists: true,
         isDefault: true,
         bbox: { min_lat: 37.71, max_lat: 37.81, min_lon: -122.51, max_lon: -122.37 },
+        boundaryGeoJson: defaultBoundaryGeoJson,
         graphReadiness: defaultGraphReadiness,
       });
     }
@@ -2967,6 +2975,7 @@ app.get('/api/sample-road-points', async (req, res) => {
   const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
   const profile = (req.query.profile as string) || 'driving-car';
   const noCache = req.query.nocache === '1';
+  const regionParam = (req.query.region as string) || '';
 
   if ([minLat, maxLat, minLon, maxLon].some(v => isNaN(v))) {
     return res.status(400).json({ ok: false, reason: 'min_lat, max_lat, min_lon, max_lon required' });
@@ -2975,7 +2984,19 @@ app.get('/api/sample-road-points', async (req, res) => {
     return res.status(400).json({ ok: false, reason: 'invalid bbox: min must be < max' });
   }
 
-  const cacheKey = roadPointsCacheKey(minLat, maxLat, minLon, maxLon, profile);
+  // Resolve the region's BOUNDARY polygon (if any) so we can clip road points
+  // server-side. For non-rectangular regions like California or Italy, the
+  // bbox alone leaks points into Nevada / Adriatic / ocean — ST_WITHIN against
+  // REGION_CATALOG.BOUNDARY removes them at the source.
+  let safeRegionForBoundary: string | null = null;
+  if (regionParam && regionParam !== 'default') {
+    try {
+      safeRegionForBoundary = sanitizeIdentifier(regionParam);
+    } catch {
+      safeRegionForBoundary = null;
+    }
+  }
+  const cacheKey = roadPointsCacheKey(minLat, maxLat, minLon, maxLon, profile) + (safeRegionForBoundary ? `|${safeRegionForBoundary}` : '');
   if (!noCache) {
     const cached = roadPointsCacheGet(cacheKey);
     if (cached) {
@@ -3003,6 +3024,12 @@ app.get('/api/sample-road-points', async (req, res) => {
   const latSpan = maxLat - minLat;
   const tileDeg = Math.max(Math.min(lonSpan, latSpan) / 8, 0.05);
 
+  // Optional polygon clip — only added when the region has a non-bbox boundary
+  // to avoid extra cost on rectangular regions where bbox already matches.
+  const polygonClip = safeRegionForBoundary
+    ? `AND ST_WITHIN(ST_STARTPOINT(GEOMETRY), (SELECT BOUNDARY FROM ${SF_DATABASE}.CORE.REGION_CATALOG WHERE (UPPER(REGION_KEY) = UPPER('${safeRegionForBoundary}') OR UPPER(REGION_NAME) = UPPER('${safeRegionForBoundary}')) AND BOUNDARY IS NOT NULL AND COALESCE(BOUNDARY_SOURCE, '') NOT IN ('bbox-fallback','bbbike-bbox') LIMIT 1))`
+    : '';
+
   // Filter on numeric BBOX:* scalars (prunable via micro-partitions on the Carto-clustered table)
   // and pick one representative road start point per coarse tile via ANY_VALUE — geographic spread
   // without an expensive ORDER BY RANDOM() over the full filtered set.
@@ -3015,6 +3042,7 @@ app.get('/api/sample-road-points', async (req, res) => {
       AND ${classFilter}
       AND BBOX:xmin <= ${maxLon} AND BBOX:xmax >= ${minLon}
       AND BBOX:ymin <= ${maxLat} AND BBOX:ymax >= ${minLat}
+      ${polygonClip}
     GROUP BY
       FLOOR((BBOX:xmin::FLOAT + BBOX:xmax::FLOAT) / 2 / ${tileDeg}),
       FLOOR((BBOX:ymin::FLOAT + BBOX:ymax::FLOAT) / 2 / ${tileDeg})

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/server/index.ts
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/server/index.ts
@@ -2565,6 +2565,75 @@ app.get('/api/datasets', async (_req, res) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// POST /api/datasets/activate — atomically activate a (region, vehicleType)
+// pair selected from the DatasetPicker. Updates VEHICLE_TYPE and REGION on
+// all 6 demo CONFIG tables in ONE server round-trip BEFORE returning, so
+// that when the React UI subsequently flips its state and remounts demo
+// components, the projection views (which read REGION/VEHICLE_TYPE via
+// `(SELECT ... FROM CONFIG LIMIT 1)`) already reflect the new selection.
+// This eliminates the race condition where demo components remount and
+// query CONFIG before /api/regions/active had time to write the new region.
+// ---------------------------------------------------------------------------
+app.post('/api/datasets/activate', async (req, res) => {
+  try {
+    const { region, vehicleType } = req.body || {};
+    if (!region || !vehicleType) {
+      return res.status(400).json({ error: 'region and vehicleType required' });
+    }
+    const safeRegion = escapeString(region);
+    const safeVehicleType = escapeString(vehicleType);
+
+    // 1. Flip IS_DEFAULT in REGION_REGISTRY (best-effort).
+    try {
+      await runSql(
+        `CALL FLEET_INTELLIGENCE.CORE.SET_ACTIVE_REGION('${safeRegion}')`,
+        'FLEET_INTELLIGENCE', 'CORE'
+      );
+    } catch (e: any) {
+      log('WARN', 'Datasets', `SET_ACTIVE_REGION not available: ${e.message?.slice(0, 100)}`);
+    }
+    activeRegionOverride = region;
+
+    // 2. Update VEHICLE_TYPE + REGION on every demo CONFIG. We use the
+    // union of the two schema lists (BACKLOAD_MATCHING is in CONFIG_SCHEMAS
+    // but not FLEET_CONFIG_SCHEMAS).
+    const ALL_CONFIG_SCHEMAS = [
+      'FLEET_INTELLIGENCE.DWELL_ANALYSIS',
+      'FLEET_INTELLIGENCE.ROUTE_DEVIATION',
+      'FLEET_INTELLIGENCE.FLEET_INTELLIGENCE_TAXIS',
+      'FLEET_INTELLIGENCE.FLEET_INTELLIGENCE_FOOD_DELIVERY',
+      'FLEET_INTELLIGENCE.RETAIL_CATCHMENT',
+      'FLEET_INTELLIGENCE.ROUTE_OPTIMIZATION',
+      'FLEET_INTELLIGENCE.BACKLOAD_MATCHING',
+    ];
+    for (const schema of ALL_CONFIG_SCHEMAS) {
+      try {
+        await runSql(
+          `UPDATE ${schema}.CONFIG SET VEHICLE_TYPE = '${safeVehicleType}', REGION = '${safeRegion}'`
+        );
+      } catch (e: any) {
+        log('WARN', 'Datasets', `Failed to update ${schema}.CONFIG: ${e.message?.slice(0, 200)}`);
+      }
+    }
+
+    // 3. Auto-seed PLACES for ROUTE_OPTIMIZATION (best-effort, mirrors
+    // /api/regions/active behaviour).
+    try {
+      await runSql(
+        `CALL FLEET_INTELLIGENCE.ROUTE_OPTIMIZATION.SEED_ROUTE_OPTIMIZATION_REGION('${safeRegion}')`,
+        'FLEET_INTELLIGENCE', 'ROUTE_OPTIMIZATION'
+      );
+    } catch (e: any) {
+      log('WARN', 'Datasets', `Auto-seed PLACES for ${region}: ${e.message?.slice(0, 200)}`);
+    }
+
+    res.json({ ok: true, region, vehicleType });
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 const ROUTING_SYSTEM_PROMPT = `You are a routing agent powered by OpenRouteService. You help users with:
 1. Driving/cycling/walking directions between locations
 2. Reachability analysis (isochrones) - areas reachable within X minutes

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/FunctionTester.tsx
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/FunctionTester.tsx
@@ -711,7 +711,7 @@ interface RoadPointsResult {
   cached?: boolean;
 }
 
-async function fetchRoadPoints(bbox: BBox, profile: string, opts?: { nocache?: boolean }): Promise<RoadPointsResult> {
+async function fetchRoadPoints(bbox: BBox, profile: string, opts?: { nocache?: boolean; region?: string }): Promise<RoadPointsResult> {
   try {
     const params = new URLSearchParams({
       min_lat: bbox.min_lat.toString(),
@@ -722,6 +722,7 @@ async function fetchRoadPoints(bbox: BBox, profile: string, opts?: { nocache?: b
       profile,
     });
     if (opts?.nocache) params.set('nocache', '1');
+    if (opts?.region && opts.region !== 'default') params.set('region', opts.region);
     const resp = await fetch(`/api/sample-road-points?${params}`);
     const data = await resp.json();
     if (data.ok && data.points?.length > 0) {
@@ -801,14 +802,30 @@ export default function FunctionTester() {
         const r = await fetch('/api/regions/provisioned');
         const data = await r.json();
         if (data.error) setRegionsError(data.error);
-        const regionList: RegionOption[] = data.regions || [];
+        const regionList: RegionOption[] = (data.regions || []).map((reg: any) => {
+          // Parse boundary GeoJSON string from REGION_CATALOG.BOUNDARY into an
+          // object so samplePoints can run polygon rejection sampling. Skip
+          // silently on parse error — falls back to bbox-only sampling.
+          if (reg && typeof reg.boundaryGeoJson === 'string') {
+            try {
+              const parsed = JSON.parse(reg.boundaryGeoJson);
+              if (parsed && (parsed.type === 'Polygon' || parsed.type === 'MultiPolygon')) {
+                return { ...reg, boundaryGeoJson: parsed };
+              }
+              return { ...reg, boundaryGeoJson: null };
+            } catch {
+              return { ...reg, boundaryGeoJson: null };
+            }
+          }
+          return reg;
+        });
         setRegions(regionList);
         const def = regionList.find((c) => c.isDefault) || regionList[0];
         if (def) {
           setSelectedRegion(def);
           let roads: [number, number][] | null = null;
           if (probeOvertureOk && def.bbox) {
-            const r = await fetchRoadPoints(def.bbox, 'driving-car');
+            const r = await fetchRoadPoints(def.bbox, 'driving-car', { region: def.region });
             roads = r.points;
             setRoadPoints(roads);
             setRoadPointsReason(roads ? null : (r.reason || 'no road points'));
@@ -865,7 +882,7 @@ export default function FunctionTester() {
     userEditedRef.current = false;
     let roads: [number, number][] | null = null;
     if (overtureAvailable && r?.bbox) {
-      const rp = await fetchRoadPoints(r.bbox, selectedProfile);
+      const rp = await fetchRoadPoints(r.bbox, selectedProfile, { region: r.region });
       roads = rp.points;
       setRoadPoints(roads);
       setRoadPointsReason(roads ? null : (rp.reason || 'no road points'));
@@ -887,7 +904,7 @@ export default function FunctionTester() {
     userEditedRef.current = false;
     let roads: [number, number][] | null = roadPoints;
     if (overtureAvailable && selectedRegion?.bbox) {
-      const rp = await fetchRoadPoints(selectedRegion.bbox, profile);
+      const rp = await fetchRoadPoints(selectedRegion.bbox, profile, { region: selectedRegion.region });
       roads = rp.points;
       setRoadPoints(roads);
       setRoadPointsReason(roads ? null : (rp.reason || 'no road points'));
@@ -899,7 +916,7 @@ export default function FunctionTester() {
     userEditedRef.current = false;
     let roads = roadPoints;
     if (overtureAvailable && selectedRegion?.bbox) {
-      const rp = await fetchRoadPoints(selectedRegion.bbox, selectedProfile, { nocache: true });
+      const rp = await fetchRoadPoints(selectedRegion.bbox, selectedProfile, { nocache: true, region: selectedRegion.region });
       roads = rp.points;
       setRoadPoints(roads);
       setRoadPointsReason(roads ? null : (rp.reason || 'no road points'));

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/function-tester/samplePoints.test.ts
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/function-tester/samplePoints.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { samplePoints, COORD_FUNCTIONS, haversineKm, isBBoxValid, mulberry32, getProfileConstraints, type BBox } from './samplePoints';
+import { samplePoints, COORD_FUNCTIONS, haversineKm, isBBoxValid, mulberry32, getProfileConstraints, pointInBoundary, type BBox, type BoundaryGeoJson } from './samplePoints';
 
 const NYC_BBOX: BBox = { min_lat: 40.4774, max_lat: 40.9176, min_lon: -74.2591, max_lon: -73.7004 };
 const SMALL_BBOX: BBox = { min_lat: 51.5, max_lat: 51.505, min_lon: -0.1, max_lon: -0.095 };
@@ -204,5 +204,166 @@ describe('utility functions', () => {
     const foot = getProfileConstraints('foot-walking', 20);
     expect(foot.minKm).toBe(0.3);
     expect(foot.maxKm).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Polygon-aware sampling: California / Italy fixtures
+// ---------------------------------------------------------------------------
+//
+// The bbox of California (and Italy) overlaps neighbouring regions and large
+// bodies of water. Without polygon rejection sampling the Function Tester
+// generates points in Nevada / the Pacific / the Adriatic, causing ORS to
+// return PointNotFound errors. The fixtures below are coarse hand-drawn
+// polygons that capture the dominant shape of each region; tests assert that
+// every sampled point falls inside the polygon (with and without seeded road
+// points).
+
+const CALIFORNIA_BBOX: BBox = { min_lat: 32.5, max_lat: 42.0, min_lon: -124.5, max_lon: -114.0 };
+const CALIFORNIA_BOUNDARY: BoundaryGeoJson = {
+  type: 'Polygon',
+  coordinates: [[
+    // Coarse outline (lon, lat) clockwise starting NW
+    [-124.4, 42.0],
+    [-120.0, 42.0],
+    [-120.0, 39.0],
+    [-114.6, 35.0],
+    [-114.5, 32.7],
+    [-117.1, 32.5],
+    [-118.5, 33.7],
+    [-120.6, 34.5],
+    [-122.0, 36.9],
+    [-123.7, 39.3],
+    [-124.4, 40.4],
+    [-124.4, 42.0],
+  ]],
+};
+
+const ITALY_BBOX: BBox = { min_lat: 36.6, max_lat: 47.1, min_lon: 6.6, max_lon: 18.5 };
+const ITALY_BOUNDARY: BoundaryGeoJson = {
+  type: 'Polygon',
+  coordinates: [[
+    // Boot-shaped coarse outline; deliberately omits Sardinia so the polygon
+    // diverges meaningfully from the bbox rectangle.
+    [7.0, 45.9],
+    [10.5, 46.9],
+    [13.7, 46.5],
+    [13.6, 45.7],
+    [13.0, 45.7],
+    [13.5, 44.0],
+    [15.0, 41.9],
+    [18.4, 40.0],
+    [17.9, 39.9],
+    [16.5, 39.5],
+    [17.0, 38.9],
+    [15.7, 38.0],
+    [13.5, 37.1],
+    [12.4, 37.6],
+    [13.0, 38.7],
+    [14.0, 40.8],
+    [13.5, 41.2],
+    [11.5, 42.4],
+    [10.0, 44.0],
+    [8.0, 44.4],
+    [7.5, 43.8],
+    [6.7, 45.1],
+    [7.0, 45.9],
+  ]],
+};
+
+function fractionInside(points: [number, number][], boundary: BoundaryGeoJson): number {
+  let inside = 0;
+  for (const [lon, lat] of points) {
+    if (pointInBoundary(lon, lat, boundary)) inside++;
+  }
+  return inside / points.length;
+}
+
+describe('polygon-aware sampling — California', () => {
+  for (const fnName of COORD_FUNCTIONS) {
+    it(`${fnName} 100% of points inside California polygon (no road points)`, () => {
+      const all: [number, number][] = [];
+      for (let seed = 1; seed <= 25; seed++) {
+        const r = samplePoints({
+          fnName,
+          bbox: CALIFORNIA_BBOX,
+          profile: 'driving-car',
+          seed,
+          boundary: CALIFORNIA_BOUNDARY,
+        });
+        if (r) all.push(...r.points);
+      }
+      expect(all.length).toBeGreaterThan(0);
+      expect(fractionInside(all, CALIFORNIA_BOUNDARY)).toBe(1);
+    });
+  }
+
+  it('DIRECTIONS rejects out-of-polygon road points (Nevada/Pacific) when boundary supplied', () => {
+    // Mix of California-valid and out-of-state road points (Las Vegas, Reno,
+    // and a coastal Pacific point well off the coast).
+    const roadPoints: [number, number][] = [
+      [-122.42, 37.77], [-118.24, 34.05], [-121.49, 38.58],   // SF, LA, Sacramento
+      [-115.14, 36.17], [-119.81, 39.53], [-124.95, 38.50],   // Las Vegas, Reno, Pacific
+    ];
+    const all: [number, number][] = [];
+    for (let seed = 1; seed <= 15; seed++) {
+      const r = samplePoints({
+        fnName: 'DIRECTIONS',
+        bbox: CALIFORNIA_BBOX,
+        profile: 'driving-car',
+        seed,
+        roadPoints,
+        boundary: CALIFORNIA_BOUNDARY,
+      });
+      if (r) all.push(...r.points);
+    }
+    expect(all.length).toBeGreaterThan(0);
+    expect(fractionInside(all, CALIFORNIA_BOUNDARY)).toBe(1);
+  });
+});
+
+describe('polygon-aware sampling — Italy', () => {
+  for (const fnName of COORD_FUNCTIONS) {
+    it(`${fnName} 100% of points inside Italy polygon`, () => {
+      const all: [number, number][] = [];
+      for (let seed = 1; seed <= 25; seed++) {
+        const r = samplePoints({
+          fnName,
+          bbox: ITALY_BBOX,
+          profile: 'driving-car',
+          seed,
+          boundary: ITALY_BOUNDARY,
+        });
+        if (r) all.push(...r.points);
+      }
+      expect(all.length).toBeGreaterThan(0);
+      expect(fractionInside(all, ITALY_BOUNDARY)).toBe(1);
+    });
+  }
+});
+
+describe('polygon-aware sampling — fallback safety', () => {
+  it('falls back to bbox sampling when boundary has no inside-bbox area', () => {
+    // Degenerate boundary that does not intersect the bbox at all — the code
+    // should still return points (within the bbox) instead of hanging.
+    const empty: BoundaryGeoJson = {
+      type: 'Polygon',
+      coordinates: [[[100, 1], [100, 2], [101, 2], [101, 1], [100, 1]]],
+    };
+    const r = samplePoints({
+      fnName: 'DIRECTIONS',
+      bbox: CALIFORNIA_BBOX,
+      profile: 'driving-car',
+      seed: 7,
+      boundary: empty,
+    });
+    expect(r).not.toBeNull();
+    expect(r!.points).toHaveLength(2);
+    for (const [lon, lat] of r!.points) {
+      expect(lon).toBeGreaterThanOrEqual(CALIFORNIA_BBOX.min_lon);
+      expect(lon).toBeLessThanOrEqual(CALIFORNIA_BBOX.max_lon);
+      expect(lat).toBeGreaterThanOrEqual(CALIFORNIA_BBOX.min_lat);
+      expect(lat).toBeLessThanOrEqual(CALIFORNIA_BBOX.max_lat);
+    }
   });
 });

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/function-tester/samplePoints.ts
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/components/function-tester/samplePoints.ts
@@ -139,8 +139,37 @@ function pickFromRoad(roadPoints: [number, number][], rand: () => number): [numb
   return [+p[0].toFixed(5), +p[1].toFixed(5)];
 }
 
+// Defense-in-depth: even when /api/sample-road-points returns clipped points
+// for a region, an upstream miss (boundary missing, bbox-fallback source) can
+// reintroduce out-of-region picks. When a boundary is supplied alongside road
+// points, retry pickFromRoad until a point lies inside the polygon, then fall
+// back to bbox-rejection sampling.
+const ROAD_BOUNDARY_RETRY = 20;
+function pickFromRoadInBoundary(
+  roadPoints: [number, number][],
+  boundary: BoundaryGeoJson,
+  rand: () => number,
+): [number, number] | null {
+  for (let i = 0; i < ROAD_BOUNDARY_RETRY; i++) {
+    const pt = pickFromRoad(roadPoints, rand);
+    if (pointInBoundary(pt[0], pt[1], boundary)) return pt;
+  }
+  // Linear scan: if any road points are inside, return one at random.
+  const inside = roadPoints.filter(p => pointInBoundary(p[0], p[1], boundary));
+  if (inside.length > 0) {
+    return pickFromRoad(inside, rand);
+  }
+  return null;
+}
+
 function sampleOne(bbox: BBox, rand: () => number, roadPoints?: [number, number][], shrink = 0, boundary?: BoundaryGeoJson | null): [number, number] {
   if (roadPoints && roadPoints.length > 0) {
+    if (boundary) {
+      const pt = pickFromRoadInBoundary(roadPoints, boundary, rand);
+      if (pt) return pt;
+      // No road point inside polygon — fall back to polygon-rejection sampling.
+      return randomPointInBoundary(boundary, bbox, rand, shrink);
+    }
     return pickFromRoad(roadPoints, rand);
   }
   if (boundary) {
@@ -159,11 +188,14 @@ function meetsSepConstraints(points: [number, number][], minKm: number, maxKm: n
   return true;
 }
 
-function samplePointNear(anchor: [number, number], minKm: number, maxKm: number, bbox: BBox, rand: () => number, roadPoints?: [number, number][]): [number, number] {
+function samplePointNear(anchor: [number, number], minKm: number, maxKm: number, bbox: BBox, rand: () => number, roadPoints?: [number, number][], boundary?: BoundaryGeoJson | null): [number, number] {
   if (roadPoints && roadPoints.length > 0) {
     const candidates = roadPoints.filter(rp => {
       const d = haversineKm(anchor, rp);
-      return d >= minKm && d <= maxKm;
+      const inDistRing = d >= minKm && d <= maxKm;
+      if (!inDistRing) return false;
+      if (boundary) return pointInBoundary(rp[0], rp[1], boundary);
+      return true;
     });
     if (candidates.length > 0) {
       const idx = Math.floor(rand() * candidates.length);
@@ -173,28 +205,42 @@ function samplePointNear(anchor: [number, number], minKm: number, maxKm: number,
     // road points are spread by tile (~degrees apart), so target ranges of a few km will
     // never match. Fall back to the nearest road points to the anchor — keeps both ends
     // on real roads (avoids angular offsets into ocean/wilderness) and stays geographically
-    // local instead of coast-to-coast.
-    const sorted = roadPoints
+    // local instead of coast-to-coast. When a polygon boundary is known, restrict the
+    // pool to in-polygon roads first.
+    const filtered = boundary
+      ? roadPoints.filter(rp => pointInBoundary(rp[0], rp[1], boundary))
+      : roadPoints;
+    const pool = (filtered.length > 0 ? filtered : roadPoints);
+    const sorted = pool
       .map(rp => ({ rp, d: haversineKm(anchor, rp) }))
       .filter(x => x.d > 0.01)
       .sort((a, b) => a.d - b.d);
     if (sorted.length > 0) {
-      const pool = sorted.slice(0, Math.min(5, sorted.length));
-      const choice = pool[Math.floor(rand() * pool.length)];
+      const top = sorted.slice(0, Math.min(5, sorted.length));
+      const choice = top[Math.floor(rand() * top.length)];
       return [+choice.rp[0].toFixed(5), +choice.rp[1].toFixed(5)];
     }
   }
   const midLat = (bbox.min_lat + bbox.max_lat) / 2;
-  const targetKm = minKm + rand() * (maxKm - minKm);
-  const angle = rand() * 2 * Math.PI;
-  const dLat = (targetKm * Math.cos(angle)) / DEG_TO_KM_LAT;
-  const dLon = (targetKm * Math.sin(angle)) / degToKmLon(midLat);
-  let lat = anchor[1] + dLat;
-  let lon = anchor[0] + dLon;
   const latRange = bbox.max_lat - bbox.min_lat;
   const lonRange = bbox.max_lon - bbox.min_lon;
-  lat = Math.max(bbox.min_lat + latRange * MIN_EDGE_MARGIN, Math.min(bbox.max_lat - latRange * MIN_EDGE_MARGIN, lat));
-  lon = Math.max(bbox.min_lon + lonRange * MIN_EDGE_MARGIN, Math.min(bbox.max_lon - lonRange * MIN_EDGE_MARGIN, lon));
+  // When a boundary polygon is known, retry the angular offset until the
+  // resulting point falls inside the polygon. Each iteration redraws a fresh
+  // angle and target distance so clusters of bad rolls are rare.
+  const maxAttempts = boundary ? 25 : 1;
+  let lat = anchor[1];
+  let lon = anchor[0];
+  for (let i = 0; i < maxAttempts; i++) {
+    const targetKm = minKm + rand() * (maxKm - minKm);
+    const angle = rand() * 2 * Math.PI;
+    const dLat = (targetKm * Math.cos(angle)) / DEG_TO_KM_LAT;
+    const dLon = (targetKm * Math.sin(angle)) / degToKmLon(midLat);
+    lat = anchor[1] + dLat;
+    lon = anchor[0] + dLon;
+    lat = Math.max(bbox.min_lat + latRange * MIN_EDGE_MARGIN, Math.min(bbox.max_lat - latRange * MIN_EDGE_MARGIN, lat));
+    lon = Math.max(bbox.min_lon + lonRange * MIN_EDGE_MARGIN, Math.min(bbox.max_lon - lonRange * MIN_EDGE_MARGIN, lon));
+    if (!boundary || pointInBoundary(lon, lat, boundary)) break;
+  }
   return [+lon.toFixed(5), +lat.toFixed(5)];
 }
 
@@ -211,7 +257,7 @@ function sampleWithSeparation(
     const first = sampleOne(bbox, rand, roadPoints, shrink, boundary);
     const pts: [number, number][] = [first];
     for (let i = 1; i < count; i++) {
-      pts.push(samplePointNear(first, constraints.minKm, constraints.maxKm, bbox, rand, roadPoints));
+      pts.push(samplePointNear(first, constraints.minKm, constraints.maxKm, bbox, rand, roadPoints, boundary));
     }
     if (meetsSepConstraints(pts, constraints.minKm, constraints.maxKm)) {
       return { points: pts };
@@ -220,7 +266,7 @@ function sampleWithSeparation(
   const first = sampleOne(bbox, rand, roadPoints, shrink, boundary);
   const pts: [number, number][] = [first];
   for (let i = 1; i < count; i++) {
-    pts.push(samplePointNear(first, constraints.minKm * 0.5, constraints.maxKm, bbox, rand, roadPoints));
+    pts.push(samplePointNear(first, constraints.minKm * 0.5, constraints.maxKm, bbox, rand, roadPoints, boundary));
   }
   return { points: pts, hint: 'Region is small — using reduced sample distances.' };
 }
@@ -257,13 +303,18 @@ function sampleOptimization(bbox: BBox, constraints: ProfileConstraints, rand: (
   // Continent-scale regions: the road-point seed is spread by tile (~degrees apart), so
   // randomly picking jobs from the full set produces a depot in NYC and jobs across the USA.
   // Keep the route plan locally meaningful by drawing all jobs from the road points nearest
-  // to the depot. This still gives a varied but routable plan.
-  if (roadPoints && roadPoints.length >= 11) {
-    const sorted = roadPoints
+  // to the depot. This still gives a varied but routable plan. When a polygon boundary is
+  // known, restrict to road points inside the polygon first.
+  const roadPool = (roadPoints && boundary)
+    ? roadPoints.filter(rp => pointInBoundary(rp[0], rp[1], boundary))
+    : roadPoints;
+  const effectivePool = (roadPool && roadPool.length >= 11) ? roadPool : roadPoints;
+  if (effectivePool && effectivePool.length >= 11) {
+    const sorted = effectivePool
       .map(rp => ({ rp, d: haversineKm(depot, rp) }))
       .filter(x => x.d > 0.01)
       .sort((a, b) => a.d - b.d)
-      .slice(0, Math.min(roadPoints.length - 1, 24));
+      .slice(0, Math.min(effectivePool.length - 1, 24));
     if (sorted.length >= 10) {
       const shuffled = [...sorted].sort(() => rand() - 0.5).slice(0, 10);
       const jobs = shuffled.map(x => [+x.rp[0].toFixed(5), +x.rp[1].toFixed(5)] as [number, number]);
@@ -314,4 +365,4 @@ export function samplePoints(input: SamplePointsInput): SampledPoints | null {
 
 export const COORD_FUNCTIONS = ['DIRECTIONS', 'ISOCHRONES', 'MATRIX', 'MATRIX_TABULAR', 'OPTIMIZATION'];
 
-export { haversineKm, isBBoxValid, mulberry32, getProfileConstraints };
+export { haversineKm, isBBoxValid, mulberry32, getProfileConstraints, pointInBoundary };

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/hooks/useRegion.ts
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/hooks/useRegion.ts
@@ -89,15 +89,21 @@ export function useRegionProvider() {
   useEffect(() => { fetchRegions(); }, [fetchRegions]);
 
   const switchRegion = useCallback(async (regionName: string) => {
-    const target = regions.find(r => r.REGION_NAME === regionName);
-    if (target) setActive(target);
-
+    // IMPORTANT: await the server-side CONFIG.REGION update BEFORE flipping
+    // React state. Otherwise `setActive` causes the App.tsx `dataKey` to
+    // change synchronously, which remounts every demo component. Those
+    // remounted components fire `useEffect` SQL queries against projection
+    // views (e.g. VW_TRIP_SUMMARY) that read REGION via `(SELECT REGION
+    // FROM CONFIG LIMIT 1)`. If the POST hasn't completed yet, CONFIG
+    // still holds the OLD region and demos render stale data.
     try {
       await fetch('/api/regions/active', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ region: regionName }),
       });
+      const target = regions.find(r => r.REGION_NAME === regionName);
+      if (target) setActive(target);
       await fetchRegions();
     } catch {
       await fetchRegions();

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/hooks/useVehicleType.ts
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/hooks/useVehicleType.ts
@@ -10,6 +10,7 @@ interface VehicleTypeContextValue {
   switchVehicleType: (type: string) => Promise<void>;
   regionsForType: (type: string) => string[];
   typesForRegion: (region: string) => string[];
+  refresh: () => Promise<void>;
 }
 
 const defaults: VehicleTypeContextValue = {
@@ -20,6 +21,7 @@ const defaults: VehicleTypeContextValue = {
   switchVehicleType: async () => {},
   regionsForType: () => [],
   typesForRegion: () => [],
+  refresh: async () => {},
 };
 
 const VehicleTypeContext = createContext<VehicleTypeContextValue>(defaults);
@@ -78,6 +80,7 @@ export function useVehicleTypeProvider() {
     switchVehicleType,
     regionsForType,
     typesForRegion,
+    refresh: fetchConfig,
   };
 
   return { value, VehicleTypeContext };

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/shared/DatasetPicker.tsx
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/shared/DatasetPicker.tsx
@@ -24,8 +24,8 @@ const PROFILE_LABELS: Record<string, string> = {
 };
 
 export default function DatasetPicker() {
-  const { switchRegion } = useRegion();
-  const { switchVehicleType } = useVehicleType();
+  const region = useRegion();
+  const vehicleTypeCtx = useVehicleType();
   const [datasets, setDatasets] = useState<Dataset[]>([]);
   const [activeLabel, setActiveLabel] = useState('Loading...');
   const [open, setOpen] = useState(false);
@@ -62,8 +62,22 @@ export default function DatasetPicker() {
     setOpen(false);
     setSwitching(true);
     try {
-      await switchVehicleType(ds.vehicleType);
-      await switchRegion(ds.region);
+      // Atomic server-side activation: updates VEHICLE_TYPE + REGION on all
+      // demo CONFIG tables in one round-trip BEFORE we touch React state.
+      // This guarantees that when contexts refresh and the App.tsx dataKey
+      // flips, every projection view (e.g. VW_TRIP_SUMMARY) already reads
+      // the new (region, vehicleType) from CONFIG.
+      await fetch('/api/datasets/activate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ region: ds.region, vehicleType: ds.vehicleType }),
+      });
+      // Re-sync React state from server (single dataKey change -> single
+      // remount of demos, with CONFIG already consistent).
+      await Promise.all([
+        vehicleTypeCtx.refresh(),
+        region.refresh(),
+      ]);
       setActiveLabel(ds.presetName);
       window.dispatchEvent(new CustomEvent('ors-region-switched'));
       await fetchDatasets();


### PR DESCRIPTION
## Summary

Three commits, two distinct fixes plus a small AGENTS.md update.

### 1. fix(ors-control-app): atomic preset activation to eliminate stale-data race (`a99d444`)

When switching presets in the DatasetPicker (e.g. `California / hgv` → `SanFrancisco / ebike`), the header label updated correctly but every demo page kept rendering the previous preset's data.

**Root cause:** `useRegion.switchRegion` called `setActive(target)` *synchronously* before awaiting `POST /api/regions/active`. That flipped `App.tsx`'s `dataKey = ${regionName}|${vehicleType}` immediately and force-remounted every demo while server-side `CONFIG.REGION` still held the old value. Most projection views (e.g. `VW_TRIP_SUMMARY`) read region via `WHERE REGION = (SELECT REGION FROM CONFIG LIMIT 1)`, so the remounted components fetched rows for the previous region.

**Fix:**
- `src/hooks/useRegion.ts` — await the POST first, then `setActive` (mirrors `switchVehicleType` ordering).
- `src/hooks/useVehicleType.ts` — expose `refresh()` so callers can re-sync React state from CONFIG.
- `server/index.ts` — new `POST /api/datasets/activate` that updates `VEHICLE_TYPE` + `REGION` on all 6 demo CONFIG schemas (DWELL_ANALYSIS, ROUTE_DEVIATION, FLEET_INTELLIGENCE_TAXIS, FLEET_INTELLIGENCE_FOOD_DELIVERY, RETAIL_CATCHMENT, ROUTE_OPTIMIZATION, BACKLOAD_MATCHING) in **one round-trip** before returning, plus `SET_ACTIVE_REGION` and the auto-seed call for `ROUTE_OPTIMIZATION.PLACES`.
- `src/shared/DatasetPicker.tsx` — call the new atomic endpoint, then `Promise.all([vehicleTypeCtx.refresh(), region.refresh()])`. Single `dataKey` transition instead of two.
- `ors_control_app_service.yaml` — image bumped to `v1.0.214`.

### 2. chore: bump ors_control_app to v1.0.213 (`f94348b`) + fix(function-tester): clip sampled points to region polygon (`be7d89a`)

FunctionTester's "sample N random coordinates" was producing points outside the active region's boundary. Sampling now clips to the region polygon (with a bbox-fallback when no polygon is available) and includes new unit tests covering the geometric edge cases.

## Test plan

- [x] Frontend `tsc -p tsconfig.json --noEmit` — clean
- [x] Server `tsc -p tsconfig.server.json --noEmit` — clean
- [x] Image `ors_control_app:v1.0.214` built (podman, linux/amd64), pushed (docker), and applied via `ALTER SERVICE … FROM @stage SPECIFICATION_FILE=…` on `fleet_test_evals`
- [x] `SYSTEM$GET_SERVICE_STATUS('OPENROUTESERVICE_APP.CORE.ORS_CONTROL_APP')` → `READY` on v1.0.214
- [x] Manually verified: `California / hgv (driving-car)` → `SanFrancisco / ebike` now shows SF/ebike data on first render in every demo (FleetTaxis, FleetDelivery, DwellAnalysis, RouteDeviation, RetailCatchment, RouteOptimization, BackloadMatching, AssetVelocity)
- [x] FunctionTester sample-points unit tests pass

## Endpoint
https://jlcmjncj-pm-fleet-test.snowflakecomputing.app
