### PR TITLE
fix(build-routing-solution): stop map auto-recenter after user pans/z…

### DIFF
--- a/.cortex/skills/build-routing-solution/openrouteservice_app/image-versions.env
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/image-versions.env
@@ -5,7 +5,7 @@ OPENROUTESERVICE_TAG=v9.0.0
 DOWNLOADER_TAG=v0.0.4
 ROUTING_REVERSE_PROXY_TAG=v1.1.5
 VROOM_DOCKER_TAG=v1.0.4
-ORS_CONTROL_APP_TAG=v1.1.89
+ORS_CONTROL_APP_TAG=v1.1.90
 
 # Upstream base image versions (pinned to avoid pulling broken releases).
 # Bump procedure: test locally with `docker run <image>:<new_tag>`, then

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/ors_control_app_service.yaml
@@ -3,11 +3,11 @@
 spec:
   containers:
     - name: ors-control-app
-      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.1.89
+      image: /openrouteservice_app/core/image_repository/ors_control_app:v1.1.90
       env:
         SNOWFLAKE_DATABASE: "OPENROUTESERVICE_APP"
         SNOWFLAKE_WAREHOUSE: "ROUTING_ANALYTICS"
-        APP_VERSION: "1.1.89"
+        APP_VERSION: "1.1.90"
       resources:
         requests:
           cpu: "1"

--- a/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/shared/MapView.tsx
+++ b/.cortex/skills/build-routing-solution/openrouteservice_app/services/ors_control_app/src/shared/MapView.tsx
@@ -91,6 +91,10 @@ export default function MapView({
   const hasFittedRef = useRef(false);
   const lastRegionRef = useRef<string | undefined>(fitTo?.regionKey);
   const forceFitRef = useRef(false);
+  // True once the user has manually panned/zoomed/rotated. Suppresses the
+  // automatic "re-fit when data leaves the viewport" behavior so a background
+  // data poll never yanks the camera back. Cleared on region change / Recenter.
+  const userMovedRef = useRef(false);
   const basemap = useMemo(() => cartoBasemap(), []);
 
   useEffect(() => {
@@ -130,13 +134,18 @@ export default function MapView({
   if (lastRegionRef.current !== fitRegionKey) {
     lastRegionRef.current = fitRegionKey;
     hasFittedRef.current = false;
+    userMovedRef.current = false;
   }
 
   useEffect(() => {
     if (!dims) return;
     if (!fitTo || !fitCoords || fitCoords.length === 0) return;
     const firstFit = !hasFittedRef.current || forceFitRef.current;
-    if (!firstFit && coordsWithinView(fitCoords, viewStateRef.current, dims.width, dims.height)) return;
+    if (!firstFit) {
+      // User took control of the camera: never auto-recenter on a data poll.
+      if (userMovedRef.current) return;
+      if (coordsWithinView(fitCoords, viewStateRef.current, dims.width, dims.height)) return;
+    }
 
     const next = fitBoundsToData({
       width: dims.width,
@@ -165,8 +174,12 @@ export default function MapView({
     }
   }
 
-  const handleViewStateChange = useCallback(({ viewState: vs }: any) => {
+  const handleViewStateChange = useCallback(({ viewState: vs, interactionState }: any) => {
     if (!isValidViewState(vs)) return;
+    if (interactionState && (interactionState.isDragging || interactionState.isPanning ||
+        interactionState.isZooming || interactionState.isRotating)) {
+      userMovedRef.current = true;
+    }
     setViewState(vs);
     onViewStateChange?.(vs);
   }, [onViewStateChange]);
@@ -174,6 +187,7 @@ export default function MapView({
   const recenter = useCallback(() => {
     forceFitRef.current = true;
     hasFittedRef.current = false;
+    userMovedRef.current = false;
     setRecenterTick(t => t + 1);
   }, []);
 

--- a/.cortex/skills/build-routing-solution/references/snowflake-scripting-guidelines.md
+++ b/.cortex/skills/build-routing-solution/references/snowflake-scripting-guidelines.md
@@ -201,4 +201,4 @@ Example: 3 ORS + 3 gateway + 1 Berlin + 3 = 10 containers → 4 nodes minimum (u
 | Downloader | downloader | v0.0.4 |
 | Gateway | routing_reverse_proxy | v1.1.5 |
 | VROOM | vroom-docker | v1.0.4 |
-| Control App | ors_control_app | v1.1.89 |
+| Control App | ors_control_app | v1.1.90 |


### PR DESCRIPTION
…ooms

MapView re-fit the camera on every data poll whenever the region boundary fell outside the viewport, snapping the user back after a deliberate pan or zoom-out (most visible on /regions, which polls every 3s). Track genuine deck.gl pointer interaction and suppress the automatic "re-fit when data leaves view" behavior once the user moves the map; clear the flag on region change and Recenter. Bumps ors_control_app image to v1.1.90.