### PR TITLE
fix(install-fleet-apps): stamp lastProgressAt in broadcast() so setup…

### DIFF
--- a/.cortex/skills/install-fleet-apps/fleet_admin_app/fleet_admin_app_service.yaml
+++ b/.cortex/skills/install-fleet-apps/fleet_admin_app/fleet_admin_app_service.yaml
@@ -17,7 +17,7 @@
 spec:
   containers:
     - name: fleet-admin-app
-      image: /openrouteservice_app/core/image_repository/fleet_admin_app:v0.1.31
+      image: /openrouteservice_app/core/image_repository/fleet_admin_app:v0.1.32
       env:
         HOSTNAME: "0.0.0.0"   # bind Next standalone to all interfaces
         SNOWFLAKE_DATABASE: "OPENROUTESERVICE_APP"

--- a/.cortex/skills/install-fleet-apps/fleet_admin_app/ui/src/server/studio/jobs.ts
+++ b/.cortex/skills/install-fleet-apps/fleet_admin_app/ui/src/server/studio/jobs.ts
@@ -708,6 +708,17 @@ async function updateDatasetRowCounts(
 
 function broadcast(job: Job, event: string, data: any) {
   job.events.push({ event, data, ts: Date.now() });
+  // Every forward-progress event refreshes the no-progress watchdog. Without
+  // this, the pre-telemetry universal-generation phase (offers/partners/anchors/
+  // participants/... - each a discrete awaited INSERT that broadcasts on
+  // completion) never stamps lastProgressAt, so the watchdog measures from
+  // job.startedAt and falsely aborts any run whose setup phase exceeds 15 min in
+  // total (e.g. a region where the anchors INSERT alone takes ~10 min), even
+  // though progress messages are streaming. Telemetry-phase liveness is covered
+  // separately by getRouteActivity() in the watchdog; this covers the setup phase.
+  if (event === 'progress' || event === 'batch') {
+    job.lastProgressAt = Date.now();
+  }
   if (job.events.length > EVENT_BUFFER_CAP) {
     job.events.splice(0, job.events.length - EVENT_BUFFER_CAP);
   }
@@ -908,9 +919,10 @@ export async function startGeneration(
       }
       // Liveness heartbeat: when ORS route calls are still completing but no
       // vehicle-day has finished yet (mid-day on a large region), surface a
-      // moving status so the UI is not frozen on "0 pts, 0 trips". This does not
-      // stamp lastProgressAt - route activity already keeps the watchdog fresh -
-      // so it cannot mask a real wedge.
+      // moving status so the UI is not frozen on "0 pts, 0 trips". It only fires
+      // when route completions genuinely advanced since the last tick, so the
+      // resulting progress broadcast (which does stamp lastProgressAt) can never
+      // mask a real wedge - no route activity means no heartbeat.
       if (lastSeenRouteCompletions >= 0 && act.completions > lastSeenRouteCompletions && job.pointsGenerated === 0) {
         const rc = routeCacheStats();
         broadcast(job, 'progress', {

--- a/.cortex/skills/install-fleet-apps/image-versions.env
+++ b/.cortex/skills/install-fleet-apps/image-versions.env
@@ -23,4 +23,4 @@ VROOM_BASE_TAG=v1.14.0
 FLEET_SA_APP_TAG=v0.1.89
 
 # Routing Platform Admin/Build console (Next 15 + @fleet-kit/core).
-FLEET_ADMIN_APP_TAG=v0.1.31
+FLEET_ADMIN_APP_TAG=v0.1.32

--- a/.cortex/skills/install-fleet-apps/references/snowflake-scripting-guidelines.md
+++ b/.cortex/skills/install-fleet-apps/references/snowflake-scripting-guidelines.md
@@ -202,4 +202,4 @@ Example: 3 ORS + 3 gateway + 1 Berlin + 3 = 10 containers → 4 nodes minimum (u
 | Gateway | routing_reverse_proxy | v1.1.5 |
 | VROOM | vroom-docker | v1.0.4 |
 | SA App | fleet_sa_app | v0.1.68 |
-| Admin App | fleet_admin_app | v0.1.31 |
+| Admin App | fleet_admin_app | v0.1.32 |


### PR DESCRIPTION
… phase doesn't false-abort

The no-progress watchdog measured idle from job.startedAt during the pre-telemetry universal-generation phase because broadcast() never updated job.lastProgressAt - only the telemetry-phase callbacks did. Any run whose setup phase (offers/partners/anchors/participants/...) exceeded 15 min total was killed despite streaming 'Inserted N ...' progress (observed on a SanFrancisco run where the anchors INSERT alone took ~10 min). Stamp lastProgressAt on every 'progress'/'batch' event. Complements the v0.1.31 telemetry-phase route-activity fix. Bump FLEET_ADMIN_APP to v0.1.32.