### PR TITLE
fix(routing-solution-cleanup): abort-safe, architecture-current teardown

### DIFF
--- a/.cortex/skills/routing-solution-cleanup/SKILL.md
+++ b/.cortex/skills/routing-solution-cleanup/SKILL.md
@@ -60,7 +60,7 @@ These are ALL object types created across all skills. The drop order reverses cr
 | 15 | Image Repositories | `SHOW IMAGE REPOSITORIES` + in tagged database | `DROP IMAGE REPOSITORY IF EXISTS <name>` |
 | 16 | File Formats | `SHOW FILE FORMATS` + in tagged database | `DROP FILE FORMAT IF EXISTS <name>` |
 | 17 | Schemas | `SHOW SCHEMAS` + comment match | `DROP SCHEMA IF EXISTS <name> CASCADE` |
-| 18 | Warehouses | `SHOW WAREHOUSES` + comment match | `ALTER WAREHOUSE <name> SUSPEND; DROP WAREHOUSE IF EXISTS <name>` |
+| 18 | Warehouses | `SHOW WAREHOUSES` + comment match | `DROP WAREHOUSE IF EXISTS <name>` (DROP does not need a prior SUSPEND) |
 | 19 | Marketplace Databases | `SHOW DATABASES` + name/origin match | `DROP DATABASE IF EXISTS <name>` |
 
 ## Step 1: Set Session Tag
@@ -177,13 +177,20 @@ DROP SCHEMA IF EXISTS FLEET_INTELLIGENCE.FLEET_INTELLIGENCE_EBIKE CASCADE;
 DROP SCHEMA IF EXISTS FLEET_INTELLIGENCE.FLEET_INTELLIGENCE_CAR CASCADE;
 DROP SCHEMA IF EXISTS FLEET_INTELLIGENCE.CORE CASCADE;
 
--- 18. Suspend and drop warehouse
-ALTER WAREHOUSE IF EXISTS ROUTING_ANALYTICS SUSPEND;
+-- 18. Drop warehouse. Do NOT `ALTER WAREHOUSE ... SUSPEND` first: on an
+--     already-suspended warehouse that raises 090064 ("Invalid state") and,
+--     under `snow sql -f`, aborts the whole script -- stranding later drops.
+--     DROP WAREHOUSE suspends implicitly.
 DROP WAREHOUSE IF EXISTS ROUTING_ANALYTICS;
 
--- 19. Drop marketplace databases (no tracking tag - match by name and origin)
+-- 19. Drop marketplace databases (no tracking tag - match by name and origin).
+--     install-fleet-apps acquires all six via CREATE DATABASE ... FROM LISTING.
 DROP DATABASE IF EXISTS OVERTURE_MAPS__PLACES;
 DROP DATABASE IF EXISTS OVERTURE_MAPS__ADDRESSES;
+DROP DATABASE IF EXISTS OVERTURE_MAPS__TRANSPORTATION;
+DROP DATABASE IF EXISTS OVERTURE_MAPS__BUILDINGS;
+DROP DATABASE IF EXISTS OVERTURE_MAPS__DIVISIONS;
+DROP DATABASE IF EXISTS SAFEGRAPH_OPEN_CENSUS_FREE;
 
 -- 20. Drop project databases (CASCADE handles all contained objects)
 DROP DATABASE IF EXISTS FLEET_INTELLIGENCE CASCADE;
@@ -283,7 +290,7 @@ To clean up objects from a single skill, set `SKILL_FILTER` to its tracking name
 | Cannot drop compute pool - active nodes | `ALTER COMPUTE POOL <name> STOP ALL;` then wait 30s before DROP |
 | Cannot drop table - has dependents | Drop dynamic tables and views first (follow phase order) |
 | Schema not empty after drops | Some objects may lack COMMENT tags. Use `DROP SCHEMA ... CASCADE` |
-| Warehouse in use | `ALTER WAREHOUSE <name> SUSPEND;` first, then DROP |
+| Warehouse in use | `DROP WAREHOUSE IF EXISTS <name>` (suspends implicitly; do NOT `ALTER ... SUSPEND` first - it aborts `snow sql -f` on an already-suspended WH) |
 | DROP APPLICATION fails | Ensure all services are stopped: `SHOW SERVICES IN APPLICATION <name>` |
 | Integration still exists after app drop | EAIs are account-level; drop them explicitly in Phase 3 |
 | SHOW AGENTS syntax error | Account may not have Cortex Agents enabled - skip that type |

--- a/.cortex/skills/routing-solution-cleanup/references/drop-order.sql
+++ b/.cortex/skills/routing-solution-cleanup/references/drop-order.sql
@@ -1,91 +1,94 @@
 -- ============================================================================
--- FULL TEARDOWN SCRIPT - Drops all objects created by routing solution skills
+-- FULL TEARDOWN SCRIPT - Drops all objects created by the fleet/routing skills
 -- ============================================================================
 -- Usage: snow sql -f .cortex/skills/routing-solution-cleanup/references/drop-order.sql -c <connection>
 --
 -- WARNING: This script is DESTRUCTIVE. It drops ALL databases, schemas, tables,
--- warehouses, compute pools, integrations, and other objects created by this project.
--- Review carefully before executing. The only surviving objects will be:
---   SNOWFLAKE (system), USER$<username> (personal), MY_WH (personal), SYSTEM_* pools
+-- warehouses, compute pools, integrations, roles, and other objects created by
+-- install-fleet-apps (and the legacy demo skills). The only surviving objects
+-- will be: SNOWFLAKE (system), USER$<username> (personal), MY_WH (personal),
+-- SYSTEM_* pools, and any objects from UNRELATED projects.
 --
 -- The drop order follows reverse-dependency: most-dependent objects first.
+-- Every statement is IF EXISTS and abort-safe: DROP handles suspend/stop
+-- implicitly, so no ALTER ... SUSPEND precedes a DROP (an ALTER on an
+-- already-suspended warehouse/task raises 090064 "Invalid state" and, under
+-- `snow sql -f`, ABORTS the whole file -- stranding every later drop).
 -- ============================================================================
 
 ALTER SESSION SET query_tag = '{"origin":"sf_sit-is-fleet","name":"oss-routing-solution-cleanup","version":{"major":2,"minor":0},"attributes":{"is_quickstart":1,"source":"sql"}}';
 
 -- ============================================================================
--- PHASE 1: Native Application (CASCADE stops SPCS services, drops app objects)
+-- PHASE 1: Stop services on fleet/ORS compute pools (so pools + DBs drop clean)
+--          STOP ALL on a pool with no services is a no-op, never an error.
 -- ============================================================================
-DROP APPLICATION IF EXISTS OPENROUTESERVICE_NATIVE_APP CASCADE;
-DROP APPLICATION PACKAGE IF EXISTS OPENROUTESERVICE_NATIVE_APP_PKG CASCADE;
+ALTER COMPUTE POOL IF EXISTS FLEET_APPS_COMPUTE_POOL STOP ALL;
+ALTER COMPUTE POOL IF EXISTS OPENROUTESERVICE_APP_COMPUTE_POOL STOP ALL;
+ALTER COMPUTE POOL IF EXISTS ORS_POOL_SANFRANCISCO STOP ALL;
+ALTER COMPUTE POOL IF EXISTS ORS_POOL_EUROPE STOP ALL;
 
 -- ============================================================================
--- PHASE 2: Compute Pools (may already be gone from CASCADE above)
+-- PHASE 2: Project + engine databases
+--   CASCADE removes contained SPCS services, agents, MCP servers, schemas,
+--   tables, views, stages, procedures, tasks, dynamic tables, notebooks, etc.
+--   (This subsumes the old per-object PHASES for agents/tasks/DTs/procs/views.)
 -- ============================================================================
-ALTER COMPUTE POOL IF EXISTS OPENROUTESERVICE_NATIVE_APP_COMPUTE_POOL STOP ALL;
-DROP COMPUTE POOL IF EXISTS OPENROUTESERVICE_NATIVE_APP_COMPUTE_POOL;
+DROP DATABASE IF EXISTS FLEET_APP CASCADE;
+DROP DATABASE IF EXISTS FLEET_INTELLIGENCE CASCADE;
+DROP DATABASE IF EXISTS SYNTHETIC_DATASETS CASCADE;
+DROP DATABASE IF EXISTS ROUTING_PLATFORM CASCADE;
+DROP DATABASE IF EXISTS STARTER_APP CASCADE;
+DROP DATABASE IF EXISTS OPENROUTESERVICE_APP CASCADE;
+-- Legacy native-app / setup databases (pre-relocation installs):
+DROP DATABASE IF EXISTS OPENROUTESERVICE_SETUP CASCADE;
 
 -- ============================================================================
--- PHASE 3: External Access Integrations, Network Rules, App Data DB
+-- PHASE 3: SAP mock landscape (landed by install-fleet-apps step 2.6)
 -- ============================================================================
-DROP INTEGRATION IF EXISTS OPENROUTESERVICE_NATIVE_APP_EXTERNAL_ACCESS_INTEGRATION_REF_EXTERNAL_ACCESS;
-DROP INTEGRATION IF EXISTS OPENROUTESERVICE_NATIVE_APP_EXTERNAL_ACCESS_CARTO_REF_EXTERNAL_ACCESS;
-DROP DATABASE IF EXISTS OPENROUTESERVICE_NATIVE_APP_APP_DATA;
+DROP DATABASE IF EXISTS MOCK_SAP CASCADE;
+DROP DATABASE IF EXISTS MOCK_TELEMATICS CASCADE;
 
 -- ============================================================================
--- PHASE 4: Cortex Agents
--- ============================================================================
--- Legacy standalone agent (retired; relocated TOOL_* now live in ROUTING_TOOLS).
--- Kept for cleanup of pre-relocation installs where the agent still exists.
-DROP AGENT IF EXISTS FLEET_INTELLIGENCE.ROUTING_AGENT.ROUTING_AGENT;
-
--- ============================================================================
--- PHASE 5: Tasks (suspend first, then drop)
--- ============================================================================
-ALTER TASK IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.LOG_SLA_ALERTS SUSPEND;
-DROP TASK IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.LOG_SLA_ALERTS;
-
--- ============================================================================
--- PHASE 6: Dynamic Tables (reverse pipeline order - downstream first)
--- ============================================================================
-DROP DYNAMIC TABLE IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.DT_DAILY_TRENDS;
-DROP DYNAMIC TABLE IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.DT_DRIVER_DWELL_SUMMARY;
-DROP DYNAMIC TABLE IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.DT_FACILITY_UTILIZATION;
-DROP DYNAMIC TABLE IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.DT_SLA_ALERTS;
-DROP DYNAMIC TABLE IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.DT_H3_CONGESTION;
-DROP DYNAMIC TABLE IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.DT_DWELL_ENRICHED;
-DROP DYNAMIC TABLE IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.DT_DWELL_SESSIONS;
-DROP DYNAMIC TABLE IF EXISTS FLEET_INTELLIGENCE.DWELL_ANALYSIS.DT_STATE_CHANGES;
-
--- ============================================================================
--- PHASE 7: Notebooks
--- ============================================================================
-DROP NOTEBOOK IF EXISTS FLEET_INTELLIGENCE.ROUTE_OPTIMIZATION.ADD_CARTO_DATA;
-DROP NOTEBOOK IF EXISTS FLEET_INTELLIGENCE.ROUTE_OPTIMIZATION.ROUTING_FUNCTIONS_AISQL;
-
--- ============================================================================
--- PHASE 8: Procedures
--- ============================================================================
-DROP PROCEDURE IF EXISTS FLEET_INTELLIGENCE.CORE.SET_ACTIVE_REGION(VARCHAR);
-DROP PROCEDURE IF EXISTS FLEET_INTELLIGENCE.ROUTING_TOOLS.TOOL_DIRECTIONS(VARCHAR, VARCHAR, VARCHAR);
-DROP PROCEDURE IF EXISTS FLEET_INTELLIGENCE.ROUTING_TOOLS.TOOL_ISOCHRONE(VARCHAR, FLOAT, VARCHAR);
-DROP PROCEDURE IF EXISTS FLEET_INTELLIGENCE.ROUTING_TOOLS.TOOL_OPTIMIZATION(VARCHAR, VARCHAR, VARCHAR);
-
--- ============================================================================
--- PHASE 9: Warehouse
--- ============================================================================
-ALTER WAREHOUSE IF EXISTS ROUTING_ANALYTICS SUSPEND;
-DROP WAREHOUSE IF EXISTS ROUTING_ANALYTICS;
-
--- ============================================================================
--- PHASE 10: Marketplace Databases (detaches listing automatically)
+-- PHASE 4: Marketplace listing databases (installer re-acquires FROM LISTING).
+--          DROP DATABASE detaches the listing automatically.
 -- ============================================================================
 DROP DATABASE IF EXISTS OVERTURE_MAPS__PLACES;
 DROP DATABASE IF EXISTS OVERTURE_MAPS__ADDRESSES;
+DROP DATABASE IF EXISTS OVERTURE_MAPS__TRANSPORTATION;
+DROP DATABASE IF EXISTS OVERTURE_MAPS__BUILDINGS;
+DROP DATABASE IF EXISTS OVERTURE_MAPS__DIVISIONS;
+DROP DATABASE IF EXISTS SAFEGRAPH_OPEN_CENSUS_FREE;
 
 -- ============================================================================
--- PHASE 11: Project Databases (CASCADE drops all schemas, tables, views, stages, etc.)
+-- PHASE 5: Compute pools (fleet/ORS only; leave unrelated project pools)
 -- ============================================================================
-DROP DATABASE IF EXISTS FLEET_INTELLIGENCE CASCADE;
-DROP DATABASE IF EXISTS SYNTHETIC_DATASETS CASCADE;
-DROP DATABASE IF EXISTS OPENROUTESERVICE_SETUP CASCADE;
+DROP COMPUTE POOL IF EXISTS FLEET_APPS_COMPUTE_POOL;
+DROP COMPUTE POOL IF EXISTS OPENROUTESERVICE_APP_COMPUTE_POOL;
+DROP COMPUTE POOL IF EXISTS ORS_POOL_SANFRANCISCO;
+DROP COMPUTE POOL IF EXISTS ORS_POOL_EUROPE;
+-- Legacy native-app pool:
+DROP COMPUTE POOL IF EXISTS OPENROUTESERVICE_NATIVE_APP_COMPUTE_POOL;
+
+-- ============================================================================
+-- PHASE 6: Warehouse (DROP does not require a prior SUSPEND; see header note)
+-- ============================================================================
+DROP WAREHOUSE IF EXISTS ROUTING_ANALYTICS;
+
+-- ============================================================================
+-- PHASE 7: External access integrations (ORS/FLEET only)
+-- ============================================================================
+DROP INTEGRATION IF EXISTS FLEET_APP_CARTO_EAI;
+DROP INTEGRATION IF EXISTS FLEET_APP_OSM_EAI;
+DROP INTEGRATION IF EXISTS ORS_CARTO_EAI;
+DROP INTEGRATION IF EXISTS ORS_OSM_EAI;
+-- Legacy native-app EAIs (pre-relocation installs):
+DROP INTEGRATION IF EXISTS OPENROUTESERVICE_NATIVE_APP_EXTERNAL_ACCESS_INTEGRATION_REF_EXTERNAL_ACCESS;
+DROP INTEGRATION IF EXISTS OPENROUTESERVICE_NATIVE_APP_EXTERNAL_ACCESS_CARTO_REF_EXTERNAL_ACCESS;
+
+-- ============================================================================
+-- PHASE 8: Roles
+-- ============================================================================
+DROP ROLE IF EXISTS FLEET_APP_ADMIN;
+DROP ROLE IF EXISTS FLEET_APP_OPS;
+DROP ROLE IF EXISTS FLEET_APP_USER;
+DROP ROLE IF EXISTS FLEET_APP_DYNAMIC_READER;


### PR DESCRIPTION
Remove the ALTER WAREHOUSE ... SUSPEND before DROP WAREHOUSE: on an already-suspended warehouse it raises 090064 (Invalid state) and, under snow sql -f, aborts the whole teardown, stranding every later drop (marketplace + project DBs, EAIs, roles). DROP WAREHOUSE suspends implicitly, so the ALTER is unnecessary.

Also refresh drop-order.sql (and SKILL.md examples) to match what install-fleet-apps actually creates today: FLEET_APP / ROUTING_PLATFORM / STARTER_APP / MOCK_SAP / MOCK_TELEMATICS databases, all six Overture + SafeGraph marketplace listing DBs, the FLEET/ORS compute pools and EAIs, and the FLEET_APP_* roles. DB CASCADE subsumes the stale per-object native-app phases (agents/tasks/DTs/procs/views).